### PR TITLE
Migrate More User Tests Over to Flask

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ from ufo import app
 class BaseConfiguration(object):
   """Configurations for running the application in production."""
 
+  TESTING = False
   WTF_CSRF_ENABLED = True
   SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(app.instance_path, 'app.db')
   SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/config.py
+++ b/config.py
@@ -12,7 +12,6 @@ class BaseConfiguration(object):
   """Configurations for running the application in production."""
 
   TESTING = False
-  WTF_CSRF_ENABLED = True
   SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(app.instance_path, 'app.db')
   SQLALCHEMY_TRACK_MODIFICATIONS = False
 
@@ -25,8 +24,6 @@ class TestConfiguration(BaseConfiguration):
   """Configurations for testing the application in development."""
 
   TESTING = True
-  WTF_CSRF_ENABLED = False
-
 
   SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
   # Unit tests are normally run in memory for speed, but a test db

--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ from ufo import app
 class BaseConfiguration(object):
   """Configurations for running the application in production."""
 
+  WTF_CSRF_ENABLED = True
   SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(app.instance_path, 'app.db')
   SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/ufo/templates/user_details.html
+++ b/ufo/templates/user_details.html
@@ -32,17 +32,22 @@
             Delete User
           </paper-button>
         </form>
-        <a href="{{ url_for('user_get_new_key_pair', user_id=user.id) }}">
-          <paper-button raised class="anchor-button">Rotate Key Pair
-        </paper-button></a>
-        <a href="{{ url_for('user_toggle_revoked', user_id=user.id) }}">
-          <paper-button raised class="anchor-button">
+        <form id="user-get-new-key-pair-form" method="post" action="{{ url_for('user_get_new_key_pair', user_id=user.id) }}">
+          <input type="hidden" name="_xsrf_token" value="{{ xsrf_token_value }}">
+          <paper-button raised onclick="submitByFormId('user-get-new-key-pair-form')" class="form-submit-button" type="submit">
+            Rotate Key Pair
+          </paper-button>
+        </form>
+        <form id="user-toggle-revoked-form" method="post" action="{{ url_for('user_toggle_revoked', user_id=user.id) }}">
+          <input type="hidden" name="_xsrf_token" value="{{ xsrf_token_value }}">
+          <paper-button raised onclick="submitByFormId('user-toggle-revoked-form')" class="form-submit-button" type="submit">
             {% if user.is_key_revoked %}
               Enable
             {% else %}
               Disable
             {% endif %} Access
-        </paper-button></a>
+          </paper-button>
+        </form>
       </div>
     </paper-card>
     {% if invite_code %}

--- a/ufo/templates/user_details.html
+++ b/ufo/templates/user_details.html
@@ -6,6 +6,7 @@
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
 {% endblock %}
 {% block body %}
+  {% set xsrf_token_value = xsrf_token() %}
   <div id="user-card-holder">
     <paper-card heading="{{ user.name }}">
       <div class="card-content">
@@ -25,9 +26,12 @@
           {{ user.public_key }}</textarea></div></iron-collapse>
       </div>
       <div class="card-actions">
-        <a href="{{ url_for('delete_user', user_id=user.id) }}">
-          <paper-button raised class="anchor-button">Delete User
-        </paper-button></a>
+        <form id="user-delete-form" method="post" action="{{ url_for('delete_user', user_id=user.id) }}">
+          <input type="hidden" name="_xsrf_token" value="{{ xsrf_token_value }}">
+          <paper-button raised onclick="submitByFormId('user-delete-form')" class="form-submit-button" type="submit">
+            Delete User
+          </paper-button>
+        </form>
         <a href="{{ url_for('user_get_new_key_pair', user_id=user.id) }}">
           <paper-button raised class="anchor-button">Rotate Key Pair
         </paper-button></a>

--- a/ufo/user.py
+++ b/ufo/user.py
@@ -11,11 +11,7 @@ import random
 
 from googleapiclient import errors
 
-def _RenderUserAdd():
-  get_all = flask.request.args.get('get_all')
-  group_key = flask.request.args.get('group_key')
-  user_key = flask.request.args.get('user_key')
-
+def _RenderUserAdd(get_all, group_key, user_key):
   credentials = oauth.getSavedCredentials()
   # TODO this should handle the case where we do not have oauth
   if not credentials:
@@ -111,22 +107,25 @@ def user_list():
 @setup_required
 def add_user():
   if flask.request.method == 'GET':
-    return _RenderUserAdd()
+    get_all = flask.request.args.get('get_all')
+    group_key = flask.request.args.get('group_key')
+    user_key = flask.request.args.get('user_key')
+    return _RenderUserAdd(get_all, group_key, user_key)
 
   manual = flask.request.form.get('manual')
   if manual:
     user_name = flask.request.form.get('user_name')
     user_email = flask.request.form.get('user_email')
-    user = User()
+    user = models.User()
     user.name = user_name
     user.email = user_email
-    database.Add(user)
+    user.Add()
   else:
     users = flask.request.form.getlist('selected_user')
     for user in users:
       # TODO we should be submitting data in a better format
       u = ast.literal_eval(user)
-      user = User()
+      user = models.User()
       user.name = u['name']['fullName']
       user.email = u['primaryEmail']
       user.Add()

--- a/ufo/user.py
+++ b/ufo/user.py
@@ -141,14 +141,13 @@ def user_details(user_id):
                                user=user,
                                invite_code=_MakeInviteCode(user))
 
-@app.route('/user/<user_id>/delete')
+@app.route('/user/<user_id>/delete', methods=['POST'])
 @setup_required
 def delete_user(user_id):
   """Delete the user corresponding to the passed in key.
 
   If we had access to a delete method then we would not use get here.
   """
-  #TODO guess what the comment is?  Yup, should be a post.
   user = models.User.GetById(user_id)
   #TODO assert user not none
   user.Delete()

--- a/ufo/user.py
+++ b/ufo/user.py
@@ -154,10 +154,9 @@ def delete_user(user_id):
 
   return flask.redirect(flask.url_for('user_list'))
 
-@app.route('/user/<user_id>/getNewKeyPair')
+@app.route('/user/<user_id>/getNewKeyPair', methods=['POST'])
 @setup_required
 def user_get_new_key_pair(user_id):
-  #TODO yeah...should be post at least
   user = models.User.GetById(user_id)
   # TODO assert user not none
   user.regenerate_key_pair()
@@ -165,10 +164,9 @@ def user_get_new_key_pair(user_id):
 
   return flask.redirect(flask.url_for('user_details', user_id=user_id))
 
-@app.route('/user/<user_id>/toggleRevoked')
+@app.route('/user/<user_id>/toggleRevoked', methods=['POST'])
 @setup_required
 def user_toggle_revoked(user_id):
-  # TODO the toggle alone means this should be a post!
   user = models.User.GetById(user_id)
   # TODO assert user not none
   user.is_key_revoked = not user.is_key_revoked

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -70,6 +70,217 @@ class UserTest(TestCase):
       details_link = flask.url_for('user_details', user_id=mock_users[x].id)
       self.assertEquals(details_link in user_list_output, True)
 
+  @patch.object(user, '_RenderUserAdd')
+  def testAddUsersGetHandler(self, mock_render):
+    """Test the add users get handler returns _RenderUserAdd's result."""
+    return_text = '<html>something here </html>'
+    mock_render.return_value = return_text
+    resp = self.client.get(flask.url_for('add_user'))
+
+    self.assertEquals(resp.data, return_text)
+
+  # @patch('user.User.InsertUsers')
+  # def testAddUsersPostHandler(self, mock_insert):
+  #   """Test the add users post handler calls to insert the specified users."""
+  #   user_1 = {}
+  #   user_1['primaryEmail'] = FAKE_EMAIL_1
+  #   user_1['name'] = {}
+  #   user_1['name']['fullName'] = FAKE_EMAIL_1
+  #   user_2 = {}
+  #   user_2['primaryEmail'] = FAKE_EMAIL_2
+  #   user_2['name'] = {}
+  #   user_2['name']['fullName'] = FAKE_EMAIL_2
+  #   user_array = []
+  #   user_array.append(user_1)
+  #   user_array.append(user_2)
+  #   data = '?selected_user={0}&selected_user={1}'.format(user_1, user_2)
+  #   response = self.testapp.post(PATHS['user_add_path'] + data)
+
+  #   mock_insert.assert_called_once_with(user_array)
+  #   self.assertEqual(response.status_int, 302)
+  #   self.assertTrue(PATHS['user_page_path'] in response.location)
+
+  # @patch('user.User.InsertUsers')
+  # def testAddUsersPostManualHandler(self, mock_insert):
+  #   """Test add users manually calls to insert the specified user."""
+  #   user_1 = {}
+  #   user_1['primaryEmail'] = FAKE_EMAIL
+  #   user_1['name'] = {}
+  #   user_1['name']['fullName'] = FAKE_NAME
+  #   user_array = []
+  #   user_array.append(user_1)
+  #   data = '?manual=true&user_name={0}&user_email={1}'.format(FAKE_NAME,
+  #                                                             FAKE_EMAIL)
+  #   response = self.testapp.post(PATHS['user_add_path'] + data)
+
+  #   mock_insert.assert_called_once_with(user_array)
+  #   self.assertEqual(response.status_int, 302)
+  #   self.assertTrue(PATHS['user_page_path'] in response.location)
+
+  # @patch('user._RenderAddUsersTemplate')
+  # @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.__init__')
+  # def testAddUsersGetHandlerNoParam(self, mock_ds, mock_get_users,
+  #                                   mock_get_by_key, mock_get_user,
+  #                                   mock_watch_users, mock_render):
+  #   """Test the add users get handler displays no users on initial get."""
+  #   # pylint: disable=too-many-arguments
+  #   mock_ds.return_value = None
+  #   self.testapp.get(PATHS['user_add_path'])
+
+  #   mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+  #   mock_get_users.assert_not_called()
+  #   mock_get_user.assert_not_called()
+  #   mock_get_by_key.assert_not_called()
+  #   mock_watch_users.assert_not_called()
+  #   mock_render.assert_called_once_with([])
+
+  # @patch('user._RenderAddUsersTemplate')
+  # @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.__init__')
+  # def testAddUsersGetHandlerWithGroup(self, mock_ds, mock_get_users,
+  #                                     mock_get_by_key, mock_get_user,
+  #                                     mock_watch_users, mock_render):
+  #   """Test the add users get handler displays users from a given group."""
+  #   # pylint: disable=too-many-arguments
+  #   mock_ds.return_value = None
+  #   # Email address could refer to group or user
+  #   group_key = 'foo@bar.mybusiness.com'
+  #   mock_get_by_key.return_value = FAKE_USER_ARRAY
+  #   self.testapp.get(PATHS['user_add_path'] + '?group_key=' + group_key)
+
+  #   mock_get_users.assert_not_called()
+  #   mock_get_user.assert_not_called()
+  #   mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+  #   mock_get_by_key.assert_called_once_with(group_key)
+  #   mock_watch_users.assert_any_call('delete')
+  #   mock_watch_users.assert_any_call('makeAdmin')
+  #   mock_watch_users.assert_any_call('undelete')
+  #   mock_watch_users.assert_any_call('update')
+  #   mock_render.assert_called_once_with(FAKE_USER_ARRAY)
+
+  # @patch('user._RenderAddUsersTemplate')
+  # @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.__init__')
+  # def testAddUsersGetHandlerWithUser(self, mock_ds, mock_get_users,
+  #                                    mock_get_by_key, mock_get_user,
+  #                                    mock_watch_users, mock_render):
+  #   """Test the add users get handler displays a given user as requested."""
+  #   # pylint: disable=too-many-arguments
+  #   mock_ds.return_value = None
+  #   # Email address could refer to group or user
+  #   user_key = 'foo@bar.mybusiness.com'
+  #   mock_get_user.return_value = FAKE_USER_ARRAY
+  #   self.testapp.get(PATHS['user_add_path'] + '?user_key=' + user_key)
+
+  #   mock_get_users.assert_not_called()
+  #   mock_get_by_key.assert_not_called()
+  #   mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+  #   mock_get_user.assert_called_once_with(user_key)
+  #   mock_watch_users.assert_any_call('delete')
+  #   mock_watch_users.assert_any_call('makeAdmin')
+  #   mock_watch_users.assert_any_call('undelete')
+  #   mock_watch_users.assert_any_call('update')
+  #   mock_render.assert_called_once_with(FAKE_USER_ARRAY)
+
+  # @patch('user._RenderAddUsersTemplate')
+  # @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.__init__')
+  # def testAddUsersGetHandlerWithAll(self, mock_ds, mock_get_users,
+  #                                   mock_get_by_key, mock_get_user,
+  #                                   mock_watch_users, mock_render):
+  #   """Test the add users get handler displays all users in a domain."""
+  #   # pylint: disable=too-many-arguments
+  #   mock_ds.return_value = None
+  #   mock_get_users.return_value = FAKE_USER_ARRAY
+  #   self.testapp.get(PATHS['user_add_path'] + '?get_all=true')
+
+  #   mock_get_by_key.assert_not_called()
+  #   mock_get_user.assert_not_called()
+  #   mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+  #   mock_get_users.assert_called_once_with()
+  #   mock_watch_users.assert_any_call('delete')
+  #   mock_watch_users.assert_any_call('makeAdmin')
+  #   mock_watch_users.assert_any_call('undelete')
+  #   mock_watch_users.assert_any_call('update')
+  #   mock_render.assert_called_once_with(FAKE_USER_ARRAY)
+
+  # @patch('user._RenderAddUsersTemplate')
+  # @patch('google_directory_service.GoogleDirectoryService.WatchUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUserAsList')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsersByGroupKey')
+  # @patch('google_directory_service.GoogleDirectoryService.GetUsers')
+  # @patch('google_directory_service.GoogleDirectoryService.__init__')
+  # def testAddUsersGetHandlerWithError(self, mock_ds, mock_get_users,
+  #                                     mock_get_by_key, mock_get_user,
+  #                                     mock_watch_users, mock_render):
+  #   """Test the add users get handler fails gracefully."""
+  #   # pylint: disable=too-many-arguments
+  #   fake_status = '404'
+  #   fake_response = MagicMock(status=fake_status)
+  #   fake_content = b'some error content'
+  #   fake_error = errors.HttpError(fake_response, fake_content)
+  #   mock_ds.side_effect = fake_error
+  #   mock_get_users.return_value = FAKE_USER_ARRAY
+  #   self.testapp.get(PATHS['user_add_path'] + '?get_all=true')
+
+  #   mock_ds.assert_called_once_with(MOCK_ADMIN.OAUTH_DECORATOR)
+  #   mock_get_by_key.assert_not_called()
+  #   mock_get_user.assert_not_called()
+  #   mock_get_users.assert_not_called()
+  #   mock_watch_users.assert_not_called()
+  #   mock_render.assert_called_once_with([], fake_error)
+
+  # @patch('user.User.InsertUsers')
+  # def testAddUsersPostHandler(self, mock_insert):
+  #   """Test the add users post handler calls to insert the specified users."""
+  #   user_1 = {}
+  #   user_1['primaryEmail'] = FAKE_EMAIL_1
+  #   user_1['name'] = {}
+  #   user_1['name']['fullName'] = FAKE_EMAIL_1
+  #   user_2 = {}
+  #   user_2['primaryEmail'] = FAKE_EMAIL_2
+  #   user_2['name'] = {}
+  #   user_2['name']['fullName'] = FAKE_EMAIL_2
+  #   user_array = []
+  #   user_array.append(user_1)
+  #   user_array.append(user_2)
+  #   data = '?selected_user={0}&selected_user={1}'.format(user_1, user_2)
+  #   response = self.testapp.post(PATHS['user_add_path'] + data)
+
+  #   mock_insert.assert_called_once_with(user_array)
+  #   self.assertEqual(response.status_int, 302)
+  #   self.assertTrue(PATHS['user_page_path'] in response.location)
+
+  # @patch('user.User.InsertUsers')
+  # def testAddUsersPostManualHandler(self, mock_insert):
+  #   """Test add users manually calls to insert the specified user."""
+  #   user_1 = {}
+  #   user_1['primaryEmail'] = FAKE_EMAIL
+  #   user_1['name'] = {}
+  #   user_1['name']['fullName'] = FAKE_NAME
+  #   user_array = []
+  #   user_array.append(user_1)
+  #   data = '?manual=true&user_name={0}&user_email={1}'.format(FAKE_NAME,
+  #                                                             FAKE_EMAIL)
+  #   response = self.testapp.post(PATHS['user_add_path'] + data)
+
+  #   mock_insert.assert_called_once_with(user_array)
+  #   self.assertEqual(response.status_int, 302)
+  #   self.assertTrue(PATHS['user_page_path'] in response.location)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -288,6 +288,17 @@ class UserTest(base_test.BaseTest):
     self.assertEquals(FAKE_MODEL_USER.private_key,
                       invite_code['networkData']['pass'])
 
+  @patch.object(models.User, 'GetById')
+  def testDeleteUserPostHandler(self, mock_get_by_id):
+    """Test the add users post handler calls to insert the specified users."""
+    mock_get_by_id.return_value = FAKE_MODEL_USER
+
+    response = self.client.post(flask.url_for('delete_user', user_id=FAKE_ID),
+                                follow_redirects=False)
+
+    FAKE_MODEL_USER.Delete.assert_called_once_with()
+    self.assert_redirects(response, flask.url_for('user_list'))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -290,7 +290,7 @@ class UserTest(base_test.BaseTest):
 
   @patch.object(models.User, 'GetById')
   def testDeleteUserPostHandler(self, mock_get_by_id):
-    """Test the add users post handler calls to insert the specified users."""
+    """Test the delete user handler calls to delete the specified user."""
     mock_get_by_id.return_value = FAKE_MODEL_USER
 
     response = self.client.post(flask.url_for('delete_user', user_id=FAKE_ID),
@@ -298,6 +298,37 @@ class UserTest(base_test.BaseTest):
 
     FAKE_MODEL_USER.Delete.assert_called_once_with()
     self.assert_redirects(response, flask.url_for('user_list'))
+
+  @patch.object(models.User, 'GetById')
+  def testUserGetNewKeyPairHandler(self, mock_get_by_id):
+    """Test get new key pair handler regenerates a key pair for the user."""
+    mock_user = MagicMock()
+    mock_get_by_id.return_value = mock_user
+
+    response = self.client.post(flask.url_for('user_get_new_key_pair',
+                                              user_id=FAKE_ID),
+                                follow_redirects=False)
+
+    mock_user.regenerate_key_pair.assert_called_once_with()
+    mock_user.Add.assert_called_once_with()
+    self.assert_redirects(response, flask.url_for('user_details',
+                                                  user_id=FAKE_ID))
+
+  @patch.object(models.User, 'GetById')
+  def testUserToggleRevokedHandler(self, mock_get_by_id):
+    """Test toggle revoked handler changes the revoked status for a user."""
+    mock_user = MagicMock(is_key_revoked=False)
+    mock_get_by_id.return_value = mock_user
+    initial_revoked_status = mock_user.is_key_revoked
+
+    response = self.client.post(flask.url_for('user_toggle_revoked',
+                                              user_id=FAKE_ID),
+                                follow_redirects=False)
+
+    self.assertEquals(not initial_revoked_status, mock_user.is_key_revoked)
+    mock_user.Add.assert_called_once_with()
+    self.assert_redirects(response, flask.url_for('user_details',
+                                                  user_id=FAKE_ID))
 
 
 if __name__ == '__main__':

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -82,7 +82,8 @@ class UserTest(TestCase):
     """Test the list user handler displays users from the database."""
     mock_users = []
     for x in range(0, len(FAKE_EMAILS_AND_NAMES)):
-      mock_user = MagicMock(id=x + 1, email=FAKE_EMAILS_AND_NAMES[x]['email'],
+      mock_user = MagicMock(id=(x + 1),
+                            email=FAKE_EMAILS_AND_NAMES[x]['email'],
                             name=FAKE_EMAILS_AND_NAMES[x]['name'])
       mock_users.append(mock_user)
     mock_get_all.return_value = mock_users

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -139,11 +139,10 @@ class UserTest(base_test.BaseTest):
     mock_ds.return_value = None
     # Email address could refer to group or user
     group_key = 'foo@bar.mybusiness.com'
-    query_string = '?group_key={0}'.format(group_key)
     mock_get_by_key.return_value = FAKE_DIRECTORY_USER_ARRAY
     mock_render_template.return_value = ''
 
-    response = self.client.get(flask.url_for('add_user') + query_string)
+    response = self.client.get(flask.url_for('add_user', group_key=group_key))
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('add_user.html', args[0])
@@ -161,11 +160,10 @@ class UserTest(base_test.BaseTest):
     mock_ds.return_value = None
     # Email address could refer to group or user
     user_key = 'foo@bar.mybusiness.com'
-    query_string = '?user_key={0}'.format(user_key)
     mock_get_user.return_value = FAKE_DIRECTORY_USER_ARRAY
     mock_render_template.return_value = ''
 
-    response = self.client.get(flask.url_for('add_user') + query_string)
+    response = self.client.get(flask.url_for('add_user', user_key=user_key))
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('add_user.html', args[0])
@@ -181,11 +179,10 @@ class UserTest(base_test.BaseTest):
     """Test add user get should display all users in a domain."""
     mock_get_saved_credentials.return_value = FAKE_CREDENTIAL
     mock_ds.return_value = None
-    query_string = '?get_all=true'
     mock_get_users.return_value = FAKE_DIRECTORY_USER_ARRAY
     mock_render_template.return_value = ''
 
-    response = self.client.get(flask.url_for('add_user') + query_string)
+    response = self.client.get(flask.url_for('add_user', get_all=True))
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('add_user.html', args[0])

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -16,14 +16,14 @@ from werkzeug.datastructures import MultiDict
 from werkzeug.datastructures import ImmutableMultiDict
 
 from . import app
-from . import base_test
+import base_test
 from . import db
 # I practically have to shorten this name so every single line doesn't go
 # over. If someone can't understand, they can use ctrl+f to look it up here.
-from . import google_directory_service as gds
-from . import models
-from . import oauth
-from . import user
+import google_directory_service as gds
+import models
+import oauth
+import user
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -45,14 +45,11 @@ for x in range(0, len(FAKE_EMAILS_AND_NAMES)):
 
 FAKE_CREDENTIAL = 'Look at me. I am a credential!'
 
-FAKE_PRIVATE_KEY = 'private key foo'
-FAKE_PUBLIC_KEY = 'public key bar'
-FAKE_IS_KEY_REVOKED = False
 FAKE_MODEL_USER = MagicMock(email=FAKE_EMAILS_AND_NAMES[0]['email'],
                             name=FAKE_EMAILS_AND_NAMES[0]['name'],
-                            private_key=FAKE_PRIVATE_KEY,
-                            public_key=FAKE_PUBLIC_KEY,
-                            is_key_revoked=FAKE_IS_KEY_REVOKED)
+                            private_key='private key foo',
+                            public_key='public key bar',
+                            is_key_revoked=False)
 FAKE_ID = 1000
 
 class UserTest(base_test.BaseTest):
@@ -193,7 +190,14 @@ class UserTest(base_test.BaseTest):
   @patch.object(gds.GoogleDirectoryService, '__init__')
   def testAddUsersGetWithError(self, mock_ds, mock_get_saved_credentials,
                               mock_render_template):
-    """Test add users get handler fails gracefully with an error."""
+    """Test add users get fails gracefully when a resource isn't found.
+
+    We need to catch errors from the google directory service module since we
+    have not yet implemented robust error handling. Here I'm simulating an
+    exception in the directory service and asserting that we catch it and still
+    render the add_user page along with the error rather than barfing
+    completely.
+    """
     mock_get_saved_credentials.return_value = FAKE_CREDENTIAL
     fake_status = '404'
     fake_response = MagicMock(status=fake_status)

--- a/ufo/xsrf.py
+++ b/ufo/xsrf.py
@@ -10,10 +10,11 @@ def xsrf_protect():
 
   Slight modification of http://flask.pocoo.org/snippets/3/
   """
-  if flask.request.method != 'GET':
-    token = flask.session.pop('_xsrf_token', None)
-    if not token or token != flask.request.form.get('_xsrf_token'):
-      abort(403)
+  if app.config['WTF_CSRF_ENABLED']:
+    if flask.request.method != 'GET':
+      token = flask.session.pop('_xsrf_token', None)
+      if not token or token != flask.request.form.get('_xsrf_token'):
+        flask.abort(403)
 
 def generate_xsrf_token():
   if '_xsrf_token' not in flask.session:

--- a/ufo/xsrf.py
+++ b/ufo/xsrf.py
@@ -10,11 +10,12 @@ def xsrf_protect():
 
   Slight modification of http://flask.pocoo.org/snippets/3/
   """
-  if app.config['WTF_CSRF_ENABLED']:
-    if flask.request.method != 'GET':
-      token = flask.session.pop('_xsrf_token', None)
-      if not token or token != flask.request.form.get('_xsrf_token'):
-        flask.abort(403)
+  if app.config['TESTING']:
+    return
+  if flask.request.method != 'GET':
+    token = flask.session.pop('_xsrf_token', None)
+    if not token or token != flask.request.form.get('_xsrf_token'):
+      flask.abort(403)
 
 def generate_xsrf_token():
   if '_xsrf_token' not in flask.session:


### PR DESCRIPTION
I'm going to add more to these in this same PR later, but I wanted to go ahead and get initial comments before I proceed too far so there's less work down the road.

Obviously, ignore all the commented out parts as those will migrated soon.

Please take a look at the change to xsrf and config as that was my easier way of disabling that during testing. We can similarly key off of any config value (it doesn't have to be WTF_CSRF_ENABLED for instance, it could be TESTING, or anything else), so long as it is different in production and testing modes.

Also note what I am asserting and what I am mocking. If this seems right then I'll continue as is, or if not, then I'll adjust what assertions we actually make moving forward. Thanks!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/11)

<!-- Reviewable:end -->
