### PR TITLE
Rename some of the functions in the basemodel

### DIFF
--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -49,18 +49,18 @@ def checkCredentialChange(response):
     json_credentials = credentials.to_json()
     if config.credentials != json_credentials:
       config.credentials = json_credentials
-      config.Add()
+      config.save()
 
   return response
 
 def get_user_config():
   """Returns the current user-defined configuration from the database"""
-  config = models.Config.GetById(0)
+  config = models.Config.query.get(0)
   if config is None:
     config = models.Config()
     config.id = 0
 
-    config.Add()
+    config.save()
 
   return config
 

--- a/ufo/base_test.py
+++ b/ufo/base_test.py
@@ -24,7 +24,7 @@ class BaseTest(TestCase):
     self.config.isConfigured = True
     self.config.id = 0
 
-    self.config.Add()
+    self.config.save()
 
   def tearDown(self):
     db.session.remove()

--- a/ufo/models.py
+++ b/ufo/models.py
@@ -5,25 +5,26 @@ from Crypto.PublicKey import RSA
 LONG_STRING_LENGTH = 1024
 
 class Model(db.Model):
+  """Helpful functions for the database models
+
+  Most method implementations are taken from
+  https://github.com/sloria/cookiecutter-flask"""
   __abstract__ = True
 
-  @classmethod
-  def GetAll(cls):
-    return cls.query.all()
+  def update(self, commit=True, **kwargs):
+    for attr, value in kwargs.items():
+      setattr(self, attr, value)
+    return commit and self.save() or self
 
-  @classmethod
-  def GetById(cls, id):
-    return cls.query.get(id)
-
-  def Add(self):
+  def save(self, commit=True):
     db.session.add(self)
-    db.session.commit()
-
+    if commit:
+      db.session.commit()
     return self
 
-  def Delete(self):
+  def delete(self, commit=True):
     db.session.delete(self)
-    db.session.commit()
+    return commit and db.session.commit()
 
 
 class Config(Model):
@@ -54,7 +55,9 @@ class User(Model):
   public_key = db.Column(db.LargeBinary())
   is_key_revoked = db.Column(db.Boolean(), default=False)
 
-  def __init__(self):
+  def __init__(self, **kwargs):
+    super(User, self).__init__(**kwargs)
+
     self.regenerate_key_pair()
 
   @staticmethod
@@ -90,9 +93,3 @@ class ProxyServer(Model):
   name = db.Column(db.String(LONG_STRING_LENGTH))
   ssh_private_key = db.Column(db.String(LONG_STRING_LENGTH))
   fingerprint = db.Column(db.String(LONG_STRING_LENGTH))
-
-  def __init__(self, ip_address, name, ssh_private_key, fingerprint):
-    self.ip_address=ip_address
-    self.name = name
-    self.ssh_private_key = ssh_private_key
-    self.fingerprint = fingerprint

--- a/ufo/setup.py
+++ b/ufo/setup.py
@@ -68,7 +68,6 @@ def setup():
     config.domain = domain
 
   config.isConfigured = True
-
-  config.Add()
+  config.save()
 
   return flask.redirect(flask.url_for('setup'))

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -50,8 +50,6 @@ FAKE_MODEL_USER = MagicMock(email=FAKE_EMAILS_AND_NAMES[0]['email'],
                             private_key='private key foo',
                             public_key='public key bar',
                             is_key_revoked=False)
-FAKE_ID = 1000
-
 class UserTest(base_test.BaseTest):
   """Test user class functionality."""
 
@@ -60,29 +58,26 @@ class UserTest(base_test.BaseTest):
     super(UserTest, self).setUp()
     super(UserTest, self).setup_config()
 
-  @patch.object(models.User, 'GetAll')
-  def testListUsersHandler(self, mock_get_all):
+  def testListUsersHandler(self):
     """Test the list user handler displays users from the database."""
-    mock_users = []
-    for x in range(0, len(FAKE_EMAILS_AND_NAMES)):
-      mock_user = MagicMock(id=(x + 1),
-                            email=FAKE_EMAILS_AND_NAMES[x]['email'],
-                            name=FAKE_EMAILS_AND_NAMES[x]['name'])
-      mock_users.append(mock_user)
-    mock_get_all.return_value = mock_users
+    users = []
+    for x in range(1, len(FAKE_EMAILS_AND_NAMES)):
+      user = models.User(email=FAKE_EMAILS_AND_NAMES[x]['email'],
+                         name=FAKE_EMAILS_AND_NAMES[x]['name'])
+      user.save()
+      users.append(user)
 
     resp = self.client.get(flask.url_for('user_list'))
     user_list_output = resp.data
 
-    self.assertEquals('Add Users' in user_list_output, True)
+    self.assertTrue('Add Users' in user_list_output)
     click_user_string = 'Click a user below to view more details.'
-    self.assertEquals(click_user_string in user_list_output, True)
+    self.assertTrue(click_user_string in user_list_output)
 
-    for x in range(0, len(FAKE_EMAILS_AND_NAMES)):
-      self.assertEquals(FAKE_EMAILS_AND_NAMES[x]['email'] in user_list_output,
-                        True)
-      details_link = flask.url_for('user_details', user_id=mock_users[x].id)
-      self.assertEquals(details_link in user_list_output, True)
+    for user in users:
+      self.assertTrue(user.email in user_list_output)
+      details_link = flask.url_for('user_details', user_id=user.id)
+      self.assertTrue(details_link in user_list_output)
 
   @patch.object(user, '_RenderUserAdd')
   def testAddUsersGetHandler(self, mock_render):
@@ -213,8 +208,7 @@ class UserTest(base_test.BaseTest):
     self.assertEquals([], kwargs['directory_users'])
     self.assertEquals(fake_error, kwargs['error'])
 
-  @patch.object(models.User, 'Add')
-  def testAddUsersPostHandler(self, mock_add):
+  def testAddUsersPostHandler(self):
     """Test the add users post handler calls to insert the specified users."""
     mock_users = []
     data = MultiDict()
@@ -231,12 +225,12 @@ class UserTest(base_test.BaseTest):
     response = self.client.post(flask.url_for('add_user'), data=data,
                                 follow_redirects=False)
 
-    self.assert_redirects(response, flask.url_for('user_list'))
-    for x in range(0, len(FAKE_EMAILS_AND_NAMES)):
-      mock_add.assert_any_call()
+    users_count = models.User.query.count()
+    self.assertEquals(len(FAKE_EMAILS_AND_NAMES), users_count)
 
-  @patch.object(models.User, 'Add')
-  def testAddUsersPostManualHandler(self, mock_add):
+    self.assert_redirects(response, flask.url_for('user_list'))
+
+  def testAddUsersPostManualHandler(self):
     """Test add users manually calls to insert the specified user."""
     data = {}
     data['manual'] = True
@@ -246,40 +240,42 @@ class UserTest(base_test.BaseTest):
     response = self.client.post(flask.url_for('add_user'), data=data,
                                 follow_redirects=False)
 
+    matched_count = models.User.query.filter_by(email=FAKE_EMAILS_AND_NAMES[0]['email']).count()
+    self.assertEqual(1, matched_count)
+
     self.assert_redirects(response, flask.url_for('user_list'))
-    mock_add.assert_called_once_with()
 
   @patch('flask.render_template')
-  @patch.object(models.User, 'GetById')
-  def testUserDetailsGet(self, mock_get_by_id, mock_render_template):
+  def testUserDetailsGet(self, mock_render_template):
     """Test the user details handler calls to render a user's information."""
-    mock_get_by_id.return_value = FAKE_MODEL_USER
+    user = models.User(email=FAKE_EMAILS_AND_NAMES[0]['email'],
+        name=FAKE_EMAILS_AND_NAMES[0]['name'])
+    user.save()
     mock_render_template.return_value = ''
 
-    response = self.client.get(flask.url_for('user_details', user_id=FAKE_ID))
+    response = self.client.get(flask.url_for('user_details', user_id=user.id))
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('user_details.html', args[0])
-    self.assertEquals(FAKE_MODEL_USER, kwargs['user'])
+    self.assertEquals(user, kwargs['user'])
     self.assertIsNone(kwargs['invite_code'])
 
   @patch('flask.render_template')
-  @patch.object(models.ProxyServer, 'GetAll')
-  @patch.object(models.User, 'GetById')
-  def testUserDetailsGetWithInvite(self, mock_get_by_id, mock_get_all_proxies,
-                                   mock_render_template):
+  def testUserDetailsGetWithInvite(self, mock_render_template):
     """Test the user details handler renders a valid invite code."""
     fake_ip = '0.1.2.3'
-    mock_proxy_server = MagicMock(ip_address=fake_ip)
-    mock_get_by_id.return_value = FAKE_MODEL_USER
-    mock_get_all_proxies.return_value = [mock_proxy_server]
+    proxy_server = models.ProxyServer(ip_address=fake_ip)
+    proxy_server.save()
+    user = models.User(email=FAKE_EMAILS_AND_NAMES[0]['email'],
+        name=FAKE_EMAILS_AND_NAMES[0]['name'])
+    user.save()
     mock_render_template.return_value = ''
 
-    response = self.client.get(flask.url_for('user_details', user_id=FAKE_ID))
+    response = self.client.get(flask.url_for('user_details', user_id=user.id))
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('user_details.html', args[0])
-    self.assertEquals(FAKE_MODEL_USER, kwargs['user'])
+    self.assertEquals(user, kwargs['user'])
     self.assertIsNotNone(kwargs['invite_code'])
 
     invite_code_json = base64.urlsafe_b64decode(kwargs['invite_code'])
@@ -287,52 +283,56 @@ class UserTest(base_test.BaseTest):
 
     self.assertEquals('Cloud', invite_code['networkName'])
     self.assertEquals(fake_ip, invite_code['networkData']['host'])
-    self.assertEquals(FAKE_MODEL_USER.email,
+    self.assertEquals(user.email,
                       invite_code['networkData']['user'])
-    self.assertEquals(FAKE_MODEL_USER.private_key,
+    self.assertEquals(user.private_key,
                       invite_code['networkData']['pass'])
 
-  @patch.object(models.User, 'GetById')
-  def testDeleteUserPostHandler(self, mock_get_by_id):
+  def testDeleteUserPostHandler(self):
     """Test the delete user handler calls to delete the specified user."""
-    mock_get_by_id.return_value = FAKE_MODEL_USER
+    user = models.User(email=FAKE_EMAILS_AND_NAMES[0]['email'],
+        name=FAKE_EMAILS_AND_NAMES[0]['name'])
+    user.save()
+    user_id = user.id
 
-    response = self.client.post(flask.url_for('delete_user', user_id=FAKE_ID),
+    response = self.client.post(flask.url_for('delete_user', user_id=user_id),
                                 follow_redirects=False)
 
-    FAKE_MODEL_USER.Delete.assert_called_once_with()
+    user = models.User.query.get(user_id)
+    self.assertIsNone(user)
     self.assert_redirects(response, flask.url_for('user_list'))
 
-  @patch.object(models.User, 'GetById')
-  def testUserGetNewKeyPairHandler(self, mock_get_by_id):
+  def testUserGetNewKeyPairHandler(self):
     """Test get new key pair handler regenerates a key pair for the user."""
-    mock_user = MagicMock()
-    mock_get_by_id.return_value = mock_user
+    user = models.User(email=FAKE_EMAILS_AND_NAMES[0]['email'],
+        name=FAKE_EMAILS_AND_NAMES[0]['name'])
+    user.save()
+    user_id = user.id
+    user_private_key = user.private_key
 
     response = self.client.post(flask.url_for('user_get_new_key_pair',
-                                              user_id=FAKE_ID),
+                                              user_id=user_id),
                                 follow_redirects=False)
 
-    mock_user.regenerate_key_pair.assert_called_once_with()
-    mock_user.Add.assert_called_once_with()
-    self.assert_redirects(response, flask.url_for('user_details',
-                                                  user_id=FAKE_ID))
+    self.assertNotEqual(user_private_key, user.private_key)
 
-  @patch.object(models.User, 'GetById')
-  def testUserToggleRevokedHandler(self, mock_get_by_id):
+    self.assert_redirects(response, flask.url_for('user_details',
+                                                  user_id=user_id))
+
+  def testUserToggleRevokedHandler(self):
     """Test toggle revoked handler changes the revoked status for a user."""
-    mock_user = MagicMock(is_key_revoked=False)
-    mock_get_by_id.return_value = mock_user
-    initial_revoked_status = mock_user.is_key_revoked
+    user = models.User(email=FAKE_EMAILS_AND_NAMES[0]['email'],
+        name=FAKE_EMAILS_AND_NAMES[0]['name'])
+    user.save()
+    initial_revoked_status = user.is_key_revoked
 
     response = self.client.post(flask.url_for('user_toggle_revoked',
-                                              user_id=FAKE_ID),
+                                              user_id=user.id),
                                 follow_redirects=False)
 
-    self.assertEquals(not initial_revoked_status, mock_user.is_key_revoked)
-    mock_user.Add.assert_called_once_with()
+    self.assertEquals(not initial_revoked_status, user.is_key_revoked)
     self.assert_redirects(response, flask.url_for('user_details',
-                                                  user_id=FAKE_ID))
+                                                  user_id=user.id))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This renames two of the functions in the Model class and updates them to
take as parameters a commit argument that determines whether the
session will actually be committed immediately following that function.

We now directoly call methods on the query attribute for the models,
allowing us to use get_or_404 and remove a few TODOs from the code

A few fixes were mode to the add_user functionality so that should
actually work (was not intending to do this, noticed some things while
working on it).

@xwsxethan this is going to have conflicts with your pending PR I think, I'll deal with those once it's merged in if that's fine.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/14)
<!-- Reviewable:end -->
