### PR TITLE
Add support for SSH-ing in to remote servers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Jinja2==2.8
 MarkupSafe==0.23
 mock==1.3.0
 oauth2client==1.5.2
+paramiko==1.16.0
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycrypto==2.6.1

--- a/ufo/models.py
+++ b/ufo/models.py
@@ -103,7 +103,7 @@ class ProxyServer(Model):
   def read_private_key_from_file_contents(self, contents):
     pkey_instance = pkey.PKey()
     for key_type, key_tag in ssh_client.SSHClient.key_type_to_tag_map.iteritems():
-      if key_tag not in contents:
+      if ('BEGIN ' + key_tag + ' PRIVATE KEY') not in contents:
         continue
 
       # Using the private implementation is, unfortunately, the best way to

--- a/ufo/models.py
+++ b/ufo/models.py
@@ -91,5 +91,7 @@ class ProxyServer(Model):
 
   ip_address = db.Column(db.String(LONG_STRING_LENGTH))
   name = db.Column(db.String(LONG_STRING_LENGTH))
-  ssh_private_key = db.Column(db.String(LONG_STRING_LENGTH))
-  fingerprint = db.Column(db.String(LONG_STRING_LENGTH))
+  ssh_private_key = db.Column(db.LargeBinary())
+  ssh_private_key_type = db.Column(db.String(LONG_STRING_LENGTH))
+  host_public_key = db.Column(db.LargeBinary())
+  host_public_key_type = db.Column(db.String(LONG_STRING_LENGTH))

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -5,6 +5,8 @@ from . import app, db, setup_required
 import flask
 import logging
 import models
+import ssh_client
+import StringIO
 
 
 def _MakeKeyString():
@@ -30,13 +32,39 @@ def _MakeKeyString():
   return key_string
 
 def _SendKeysToServer(server, keys):
-  #TODO implement
-  pass
+  client = ssh_client.SSHClient()
+  client.connect(server)
+
+  # TODO do stuff
+
+  client.close()
+
+def _GetViewDataFromProxyServer(server):
+  public_key = ssh_client.SSHClient.public_key_data_to_object(
+      server.host_public_key_type,
+      server.host_public_key)
+  private_key = ssh_client.SSHClient.private_key_data_to_object(
+      server.ssh_private_key_type,
+      server.ssh_private_key)
+  private_key_file = StringIO.StringIO()
+  private_key.write_private_key(private_key_file)
+  private_key_text = private_key_file.getvalue()
+
+  return {
+    "id": server.id,
+    "name": server.name,
+    "ip_address": server.ip_address,
+    "public_key": public_key.get_name() + ' ' + public_key.get_base64(),
+    "private_key": private_key_text,
+    }
+
 
 @app.route('/proxyserver/list')
 @setup_required
 def proxyserver_list():
-  proxy_servers = models.ProxyServer.query.all()
+  proxy_servers_data = models.ProxyServer.query.all()
+  proxy_servers = [_GetViewDataFromProxyServer(s) for s in proxy_servers_data]
+
   return flask.render_template('proxy_server.html',
                                proxy_servers=proxy_servers)
 
@@ -50,9 +78,20 @@ def proxyserver_add():
 
   server = models.ProxyServer(
       name=flask.request.form.get('name'),
-      ip_address=flask.request.form.get('ip_address'),
-      ssh_private_key=flask.request.form.get('ssh_private_key'),
-      fingerprint=flask.request.form.get('fingerprint'))
+      ip_address=flask.request.form.get('ip_address'))
+
+  #TODO more robust validation here and in proxyserver_edit
+  public_key_contents = flask.request.form.get('public_key')
+  if public_key_contents is None:
+    flask.abort(400)
+
+  private_key_contents = flask.request.form.get('private_key')
+  if private_key_contents is None:
+    flask.abort(400)
+
+  server.read_public_key_from_file_contents(public_key_contents)
+  server.read_private_key_from_file_contents(private_key_contents)
+
   server.save()
 
   return flask.redirect(flask.url_for('proxyserver_list'))
@@ -63,13 +102,15 @@ def proxyserver_edit(server_id):
   server = models.ProxyServer.query.get_or_404(server_id)
 
   if flask.request.method == 'GET':
+    server_for_view = _GetViewDataFromProxyServer(server)
     return flask.render_template('proxy_server_form.html',
-                                 proxy_server=server)
+                                 proxy_server=server_for_view)
 
   server.name = flask.request.form.get('name')
   server.ip_address = flask.request.form.get('ip_address')
-  server.ssh_private_key = flask.request.form.get('ssh_private_key')
-  server.fingerprint = flask.request.form.get('fingerprint')
+
+  server.read_public_key_from_file_contents(flask.request.form.get('public_key'))
+  server.read_private_key_from_file_contents(flask.request.form.get('private_key'))
   server.save()
 
   return flask.redirect(flask.url_for('proxyserver_list'))

--- a/ufo/ssh_client.py
+++ b/ufo/ssh_client.py
@@ -1,0 +1,106 @@
+import base64
+import StringIO
+
+import paramiko
+from paramiko import rsakey
+from paramiko import dsskey
+from paramiko import ecdsakey
+
+class InvalidKeyTypeException(Exception):
+  pass
+
+RSA_KEY_TYPE = 'ssh-rsa'
+DSS_KEY_TYPE = 'ssh-dss'
+EC_KEY_TYPE = 'ecdsa-sha2-nistp256'
+
+class SSHClient(paramiko.SSHClient):
+  """An SSH client that uses a ProxyServer model to set up a connection
+  """
+
+  key_type_to_tag_map = {
+      RSA_KEY_TYPE: 'RSA',
+      DSS_KEY_TYPE: 'DSA',
+      EC_KEY_TYPE: 'EC',
+      }
+
+  def connect(self, proxy_server):
+    if not self.validate_key_type(proxy_server.host_public_key_type):
+      raise InvalidKeyTypeException('Invalid public key type')
+    if not self.validate_key_type(proxy_server.ssh_private_key_type):
+      raise InvalidKeyTypeException('Invalid private key type')
+
+    # add proper verification for the server
+    host_keys = self.get_host_keys()
+    host_keys.clear()
+
+    public_key = self.public_key_data_to_object(
+        proxy_server.host_public_key_type,
+        proxy_server.host_public_key)
+
+    host_keys.add(
+        proxy_server.ip_address,
+        proxy_server.host_public_key_type,
+        public_key)
+
+    # setup the auntentication information needed to connect to the server
+    authentication_key = self.private_key_data_to_object(
+        proxy_server.ssh_private_key_type,
+        proxy_server.ssh_private_key)
+
+    return super(SSHClient, self).connect(
+        proxy_server.ip_address,
+        username='root',
+        pkey=authentication_key,
+        allow_agent=False,
+        look_for_keys=False)
+
+  @classmethod
+  def validate_key_type(cls, key_type):
+    return key_type in cls.key_type_to_tag_map
+
+  @classmethod
+  def get_key_type_from_private_key_tag(cls, private_key_tag):
+    for k, v in cls.key_type_to_tag_map.iteritems():
+      if v == private_key_tag:
+        return k
+
+    raise InvalidKeyTypeException()
+
+  @classmethod
+  def public_key_data_to_object(cls, key_type, key_data):
+    """Get a PKey object for a given public key type from data
+
+    This is unfortunately a hack around the Paramiko library not giving us a
+    good way to represent a generic public key with binary encoding, the
+    alternative way to do this would be to have a (fake) host file containing
+    one line and hoping the Paramiko code will correctly parses out the key
+    type from there"""
+
+    # TODO https://github.com/paramiko/paramiko/issues/663 (everything but
+    # rsa currently fails)
+    if key_type == RSA_KEY_TYPE:
+      return rsakey.RSAKey(data=key_data)
+    elif key_type == DSS_KEY_TYPE:
+      return dsskey.DSSKey(data=key_data)
+    elif key_type == EC_KEY_TYPE:
+      return ecdsakey.ECDSAKey(data=key_data)
+
+  @classmethod
+  def private_key_data_to_object(cls, key_type, key_data):
+    fake_file = cls._get_fake_private_key_file(key_type, key_data)
+
+    if key_type == RSA_KEY_TYPE:
+      return rsakey.RSAKey.from_private_key(fake_file)
+    elif key_type == DSS_KEY_TYPE:
+      return dsskey.DSSKey.from_private_key(fake_file)
+    elif key_type == EC_KEY_TYPE:
+      return ecdsakey.ECDSAKey.from_private_key(fake_file)
+
+  @classmethod
+  def _get_fake_private_key_file(cls, key_type, key_data):
+    key_tag = cls.key_type_to_tag_map[key_type]
+    prefix = '-----BEGIN ' + key_tag + ' PRIVATE KEY-----'
+    body = base64.b64encode(key_data)
+    suffix = '-----END ' + key_tag + ' PRIVATE KEY-----'
+
+    return StringIO.StringIO(prefix + '\n' + body + '\n' + suffix)

--- a/ufo/templates/proxy_server.html
+++ b/ufo/templates/proxy_server.html
@@ -4,6 +4,8 @@
   <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='bower_components/paper-input/paper-input.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='bower_components/paper-input/paper-textarea.html') }}" />
 {% endblock %}
 {% block body %}
   <a href="{{ url_for('proxyserver_add') }}">
@@ -13,11 +15,15 @@
   {% for proxy_server in proxy_servers %}
     <paper-card heading="{{ proxy_server.name }}">
       <div class="card-content">
-        <p>{{ proxy_server.ip_address }}, {{ proxy_server.fingerprint }}</p>
-        <paper-button onclick="toggleCollapse('collapse-{{loop.index}}')">Show/hide SSH Key</paper-button>
+        <p>{{ proxy_server.ip_address }}</p>
+        <paper-button onclick="toggleCollapse('collapse-{{loop.index}}')">Show/hide SSH Keys</paper-button>
         <iron-collapse id="collapse-{{loop.index}}"><div>
-          <textarea rows="20" cols="80">{{ proxy_server.ssh_private_key }}
-          </textarea></div></iron-collapse>
+          <h3>Public Key (for verification)</h3>
+          <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{proxy_server.public_key}}</pre>
+
+          <h3>Private Key (for authentication)</h3>
+          <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{proxy_server.private_key}}</pre>
+        </iron-collapse>
       </div>
       <div class="card-actions">
         <a href="{{ url_for('proxyserver_edit', server_id=proxy_server.id) }}">

--- a/ufo/templates/proxy_server_form.html
+++ b/ufo/templates/proxy_server_form.html
@@ -3,13 +3,32 @@
 {% block head %}
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-input/paper-input.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='bower_components/paper-input/paper-textarea.html') }}" />
 {% endblock %}
 {% block body %}
   <form id="proxy-edit-add-form" method="post">
     <paper-input label="IP Address" type="text" name="ip_address" value="{{ proxy_server.ip_address }}" required></paper-input>
     <paper-input label="Name" type="text" name="name" value="{{ proxy_server.name }}" required></paper-input>
-    <paper-input label="SSH Private Key" type="text" name="ssh_private_key" value="{{ proxy_server.ssh_private_key }}" required></paper-input>
-    <paper-input label="Fingerprint" type="text" name="fingerprint" value="{{ proxy_server.fingerprint }}" required></paper-input>
+
+    <!-- TODO add the ability to upload files -->
+
+    <p>
+      For the private key, please copy the full contents of a private key file
+      with the ability to access a proxy server.  The beginning of the file
+      should resemble "-----BEGIN RSA PRIVATE KEY-----".
+    </p>
+    <!-- TODO this does not actually work with the real version of paper-textarea -->
+    <paper-textarea label="SSH Private Key" name="private_key" value="{{ proxy_server.private_key }}" required></paper-textarea>
+
+    <p>
+      For the hosts public key, you can usually get this value from either
+      /etc/ssh/ssh_host_rsa_key.pub or from the line in $HOME/.ssh/known_hosts on
+      your server.
+    </p>
+    <p>
+      For now, please be sure to use an RSA key (the text should begin with ssh-rsa).
+    </p>
+    <paper-input label="SSH Host Public Key" type="text" name="public_key" value="{{ proxy_server.public_key }}" required></paper-input>
     <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}">
     <paper-button raised onclick="submitByFormId('proxy-edit-add-form')" class="form-submit-button" type="submit">Submit</paper-button>
   </form>


### PR DESCRIPTION
This adds an SSHClient class that extends the native Paramiko SSHClient.
It overrides the connect method so that it will now accept a
ProxyServer model as the argument and connect to that server.

Submitting this mostly for thoughts right now, it's pretty much just a ton of hacking around the Paramiko API to get it to do what we want.

I'm open to other ways of structuring things, this felt like a good first step though.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/16)
<!-- Reviewable:end -->
