### PR TITLE
New Google Directory Service Tests

### DIFF
--- a/ufo/google_directory_service.py
+++ b/ufo/google_directory_service.py
@@ -5,22 +5,20 @@ import httplib2
 from googleapiclient import discovery
 
 MY_CUSTOMER_ALIAS = 'my_customer'
-
 NUM_RETRIES = 3
-
-VALID_WATCH_EVENTS = ['add', 'delete', 'makeAdmin', 'undelete', 'update']
-
-# TODO(eholder): Write tests for these functions.
 
 class GoogleDirectoryService(object):
 
   """Interact with Google Directory API."""
 
-  def __init__(self, credentials):
+  def __init__(self, credentials, http=None):
     """Create a service object for admin directory services using oauth."""
+    if http is None:
+      http = credentials.authorize(httplib2.Http())
     self.service = discovery.build(serviceName='admin',
                                    version='directory_v1',
-                                   http=credentials.authorize(httplib2.Http()))
+                                   http=http,
+                                   developerKey='myapikey1234')
 
   def GetUsers(self):
     """Get the users of a customer account.

--- a/ufo/google_directory_service.py
+++ b/ufo/google_directory_service.py
@@ -11,14 +11,11 @@ class GoogleDirectoryService(object):
 
   """Interact with Google Directory API."""
 
-  def __init__(self, credentials, http=None):
+  def __init__(self, credentials):
     """Create a service object for admin directory services using oauth."""
-    if http is None:
-      http = credentials.authorize(httplib2.Http())
     self.service = discovery.build(serviceName='admin',
                                    version='directory_v1',
-                                   http=http,
-                                   developerKey='myapikey1234')
+                                   http=credentials.authorize(httplib2.Http()))
 
   def GetUsers(self):
     """Get the users of a customer account.

--- a/ufo/google_directory_service_test.py
+++ b/ufo/google_directory_service_test.py
@@ -1,0 +1,63 @@
+"""Test google directory service module functionality."""
+from mock import MagicMock
+from mock import patch
+
+import flask
+from googleapiclient import http
+import json
+import unittest
+
+import base_test
+# I practically have to shorten this name so every single line doesn't go
+# over. If someone can't understand, they can use ctrl+f to look it up here.
+import google_directory_service as gds
+
+
+FAKE_EMAIL_1 = 'foo@mybusiness.com'
+FAKE_EMAIL_2 = 'bar@mybusiness.com'
+FAKE_USER_1 = {}
+FAKE_USER_1['primaryEmail'] = FAKE_EMAIL_1
+FAKE_USER_1['isAdmin'] = True
+FAKE_USER_2 = {}
+FAKE_USER_2['primaryEmail'] = FAKE_EMAIL_2
+FAKE_USER_2['isAdmin'] = False
+FAKE_USERS = [FAKE_USER_1, FAKE_USER_2]
+
+
+def make_mock_directory_service(http_mock):
+  """Create a mocked out google directory service with the http mock passed."""
+  # Setting up mocks for the service based on the example shown here:
+  # https://developers.google.com/api-client-library/python/guide/mocks
+  # def mock_authorize(http):
+  #   """Mock authorize function to return a mocked object."""
+  #   return http_mock
+
+  # mock_credentials = MagicMock()
+  # mock_credentials.authorize = mock_authorize
+  directory_service = gds.GoogleDirectoryService(None, http=http_mock)
+  return directory_service
+
+
+class GoogleDirectoryServiceTest(base_test.BaseTest):
+  """Test google directory service class functionality."""
+
+  def setUp(self):
+    """Setup test app on which to call handlers and db to query."""
+    super(GoogleDirectoryServiceTest, self).setUp()
+    super(GoogleDirectoryServiceTest, self).setup_config()
+
+  def testGetUsers(self):
+    """Test the get users request handles a valid response correctly."""
+    fake_dictionary = {}
+    fake_dictionary['users'] = FAKE_USERS
+    json_dictionary = json.dumps(fake_dictionary)
+    http_mock = http.HttpMockSequence([({'status': '200'}, json_dictionary)])
+    directory_service = make_mock_directory_service(http_mock)
+
+    users_returned = directory_service.GetUsers()
+
+    self.assertEqual(users_returned, FAKE_USERS)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
I attempted to utilize the mocking style provided here: https://developers.google.com/api-client-library/python/guide/mocks

However, I could not get GDS to build with the mock http sequence. It may work if we capture an entire request and response into a json file as they suggest, but since we're dealing with the directory service, that would imply that we keep a json file somewhere containing an entire blob for a domain which will then contain PII about all users in the domain. We can of course modify this to be fake data, but overall that approach seems like more work than just mocking out the calls we need directly. Please take a look at how I've done it here and see what you both think, @blueandgold and @jpevarnek .

I'll expand this to tests for the other methods if we agree that this seems feasible. Thanks!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/17)
<!-- Reviewable:end -->
