### PR TITLE
Migrating Web Driver Functional Tests Over to Flask Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ venv/*
 *.pyc
 ufo/static/bower_components/*
 node_modules/*
-lib/*
+chrome_driver/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/*
 *.pyc
 ufo/static/bower_components/*
 node_modules/*
+lib/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycrypto==2.6.1
 rsa==3.2.3
+selenium==2.49.2
 simplejson==3.8.1
 six==1.10.0
 SQLAlchemy==1.0.11

--- a/tests/ui/base_driver.py
+++ b/tests/ui/base_driver.py
@@ -1,0 +1,11 @@
+"""Base driver module to inherit from."""
+
+class BaseDriver(object):
+
+  """Base driver that will be called from all pages and elements."""
+
+  # pylint: disable=too-few-public-methods
+
+  def __init__(self, driver):
+    """Create the base driver object."""
+    self.driver = driver

--- a/tests/ui/base_test.py
+++ b/tests/ui/base_test.py
@@ -6,8 +6,7 @@ class BaseTest(unittest.TestCase):
 
   """Base test class to inherit from."""
 
-  def __init__(self, methodName='runTest', args=None, kwargs=None):
+  def __init__(self, methodName='runTest', args=None, **kwargs):
     """Create the base test object for others to inherit."""
-    super(BaseTest, self).__init__(methodName)
+    super(BaseTest, self).__init__(methodName, **kwargs)
     self.args = args
-    self.kwargs = kwargs

--- a/tests/ui/base_test.py
+++ b/tests/ui/base_test.py
@@ -1,0 +1,12 @@
+"""Test base module functionality."""
+
+import unittest
+
+class BaseTest(unittest.TestCase):
+
+  """Base test class to inherit from."""
+
+  def __init__(self, methodName='runTest', args=None):
+    """Create the base test object for others to inherit."""
+    super(BaseTest, self).__init__(methodName)
+    self.args = args

--- a/tests/ui/base_test.py
+++ b/tests/ui/base_test.py
@@ -6,7 +6,8 @@ class BaseTest(unittest.TestCase):
 
   """Base test class to inherit from."""
 
-  def __init__(self, methodName='runTest', args=None):
+  def __init__(self, methodName='runTest', args=None, kwargs=None):
     """Create the base test object for others to inherit."""
     super(BaseTest, self).__init__(methodName)
     self.args = args
+    self.kwargs = kwargs

--- a/tests/ui/landing_page.py
+++ b/tests/ui/landing_page.py
@@ -1,0 +1,24 @@
+"""Landing page module for testing."""
+from base_driver import BaseDriver
+from sidebar import Sidebar
+
+from selenium.webdriver.common.by import By
+
+class LandingPage(BaseDriver):
+
+  """Home page action methods and locators."""
+
+  TITLE = (By.TAG_NAME, 'h2')
+  INSTRUCTION = (By.TAG_NAME, 'h4')
+
+  def GetTitle(self):
+    """Get the title element on the landing page."""
+    return self.driver.find_element(*self.TITLE)
+
+  def GetInstruction(self):
+    """Get the instructions element on the landing page."""
+    return self.driver.find_element(*self.INSTRUCTION)
+
+  def GetSidebar(self):
+    """Get the sidebar element on the landing page."""
+    return self.driver.find_element(*Sidebar.SIDEBAR)

--- a/tests/ui/landing_page_test.py
+++ b/tests/ui/landing_page_test.py
@@ -20,6 +20,9 @@ class LandingPageTest(BaseTest):
 
   def testLandingPage(self):
     """Test the landing page."""
+    # TODO(eholder): Improve the checks here to be based on something more
+    # robust, such as the presence of element id's or that the page renders
+    # as expected, since this text can change in the future and is not i18ned.
     title = u'Uproxy for Organizations Management Server'
     instruction = ('Click one of the links on the side to login and '
                    'administer the server.')

--- a/tests/ui/landing_page_test.py
+++ b/tests/ui/landing_page_test.py
@@ -1,0 +1,40 @@
+"""Test langing page module functionality."""
+import unittest
+
+from base_test import BaseTest
+from landing_page import LandingPage
+from test_config import CHROME_DRIVER_LOCATION
+
+from selenium import webdriver
+
+
+class LandingPageTest(BaseTest):
+
+  """Test landing page functionality."""
+
+  def setUp(self):
+    """Setup for test methods."""
+    self.driver = webdriver.Chrome(CHROME_DRIVER_LOCATION)
+    # TODO(eholder) Re-enable this once we have a login module again.
+    # LoginPage(self.driver).Login(self.args)
+
+  def testLandingPage(self):
+    """Test the landing page."""
+    title = u'Uproxy for Organizations Management Server'
+    instruction = ('Click one of the links on the side to login and '
+                   'administer the server.')
+
+    self.driver.get(self.args.server_url)
+
+    landing_page = LandingPage(self.driver)
+    self.assertEquals(title, landing_page.GetTitle().text)
+    self.assertEquals(instruction, landing_page.GetInstruction().text)
+    self.assertIsNotNone(landing_page.GetSidebar())
+
+  def tearDown(self):
+    """Teardown for test methods."""
+    self.driver.quit()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/ui/sidebar.py
+++ b/tests/ui/sidebar.py
@@ -1,0 +1,27 @@
+"""Sidebar module to get links for testing."""
+from base_driver import BaseDriver
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+class Sidebar(BaseDriver):
+
+  """Sidebar action methods and locators."""
+
+  # pylint: disable=too-few-public-methods
+
+  SIDEBAR = (By.TAG_NAME, 'ufo-sidebar')
+
+  HOME_LINK = (By.ID, 'Home')
+  USERS_LINK = (By.ID, 'Users')
+  PROXY_SERVERS_LINK = (By.ID, 'Proxy Servers')
+  SETUP_LINK = (By.ID, 'Setup')
+  LOGOUT_LINK = (By.ID, 'Logout')
+
+
+  def GetLink(self, link_locator):
+    """Get an element in the sidebar based on the link locator given."""
+    # return self.driver.find_element(*link_locator)
+    return WebDriverWait(self.driver, 10).until(
+        EC.visibility_of_element_located(((link_locator))))

--- a/tests/ui/sidebar_test.py
+++ b/tests/ui/sidebar_test.py
@@ -44,7 +44,7 @@ class SidebarTest(BaseTest):
                       setup_link.get_attribute('data-href'))
 
     logout_link = sidebar.GetLink(sidebar.LOGOUT_LINK)
-    self.assertEquals('/logout', logout_link.get_attribute('data-href'))
+    self.assertEquals('/logout/', logout_link.get_attribute('data-href'))
 
   def tearDown(self):
     """Teardown for test methods."""

--- a/tests/ui/sidebar_test.py
+++ b/tests/ui/sidebar_test.py
@@ -1,0 +1,55 @@
+"""Test sidebar module functionality."""
+import unittest
+
+from base_test import BaseTest
+from sidebar import Sidebar
+from test_config import CHROME_DRIVER_LOCATION
+from ufo import app
+
+import flask
+from selenium import webdriver
+
+
+class SidebarTest(BaseTest):
+
+  """Test sidebar partial page functionality."""
+
+  def setUp(self):
+    """Setup for test methods."""
+    self.driver = webdriver.Chrome(CHROME_DRIVER_LOCATION)
+    # TODO(eholder) Re-enable this once we have a login module again.
+    # LoginPage(self.driver).Login(self.args)
+    self.context = app.test_request_context()
+    self.context.push()
+
+  def testLinks(self):
+    """Make sure all the links are pointed to the correct paths."""
+    self.driver.get(self.args.server_url)
+    sidebar = Sidebar(self.driver)
+
+    home_link = sidebar.GetLink(sidebar.HOME_LINK)
+    self.assertEquals(flask.url_for('landing'),
+                      home_link.get_attribute('data-href'))
+
+    users_link = sidebar.GetLink(sidebar.USERS_LINK)
+    self.assertEquals(flask.url_for('user_list'),
+                      users_link.get_attribute('data-href'))
+
+    proxy_servers_link = sidebar.GetLink(sidebar.PROXY_SERVERS_LINK)
+    self.assertEquals(flask.url_for('proxyserver_list'),
+                      proxy_servers_link.get_attribute('data-href'))
+
+    setup_link = sidebar.GetLink(sidebar.SETUP_LINK)
+    self.assertEquals(flask.url_for('setup'),
+                      setup_link.get_attribute('data-href'))
+
+    logout_link = sidebar.GetLink(sidebar.LOGOUT_LINK)
+    self.assertEquals('/logout', logout_link.get_attribute('data-href'))
+
+  def tearDown(self):
+    """Teardown for test methods."""
+    self.driver.quit()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -4,4 +4,4 @@
 import sys
 sys.path.append('../..')
 
-CHROME_DRIVER_LOCATION = '../../lib/chromedriver'
+CHROME_DRIVER_LOCATION = '../../chrome_driver/chromedriver'

--- a/tests/ui/test_config.py
+++ b/tests/ui/test_config.py
@@ -1,0 +1,7 @@
+"""Configs for the ui tests."""
+
+# Hack to make the app directory to be visible here.
+import sys
+sys.path.append('../..')
+
+CHROME_DRIVER_LOCATION = '../../lib/chromedriver'

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -1,0 +1,38 @@
+"""Test runner for functional testing."""
+import argparse
+import unittest
+
+from landing_page_test import LandingPageTest
+from sidebar_test import SidebarTest
+from user_page_test import UserPageTest
+
+
+def _ParseArgs():
+  """Parse the arguments from the commandline."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--server_url', action='store',
+                      dest='server_url', default=None,
+                      help='URL of the server to test.')
+  parser.add_argument('--email', action='store',
+                      dest='email', default=None,
+                      help='Email of the user to login.')
+  parser.add_argument('--password', action='store',
+                      dest='password', default=None,
+                      help='Password of the user to login.')
+  return parser.parse_args()
+
+def MakeSuite(testcase_class):
+  """Add the test cases into suites."""
+  testloader = unittest.TestLoader()
+  test_cases = testloader.getTestCaseNames(testcase_class)
+  test_suite = unittest.TestSuite()
+  for test_case in test_cases:
+    test_suite.addTest(testcase_class(test_case, args=_ParseArgs()))
+  return test_suite
+
+SUITE = unittest.TestSuite()
+SUITE.addTest(MakeSuite(LandingPageTest))
+SUITE.addTest(MakeSuite(UserPageTest))
+SUITE.addTest(MakeSuite(SidebarTest))
+
+unittest.TextTestRunner().run(SUITE)

--- a/tests/ui/user_page.py
+++ b/tests/ui/user_page.py
@@ -1,0 +1,24 @@
+"""User page module functionality for getting elements for testing."""
+from base_driver import BaseDriver
+from sidebar import Sidebar
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+class UserPage(BaseDriver):
+
+  """User page action methods and locators."""
+
+  ADD_USERS_LINK = (By.ID, 'add_users')
+
+
+  def GetAddUserLink(self):
+    """Get the add user element on the user page."""
+    return WebDriverWait(self.driver, 10).until(
+        EC.visibility_of_element_located(((self.ADD_USERS_LINK))))
+
+  def GetSidebar(self):
+    """Get the sidebar element on the user page."""
+    return self.driver.find_element(*Sidebar.SIDEBAR)

--- a/tests/ui/user_page_test.py
+++ b/tests/ui/user_page_test.py
@@ -1,0 +1,40 @@
+"""Test user page module functionality."""
+import unittest
+
+from base_test import BaseTest
+from test_config import CHROME_DRIVER_LOCATION
+from ufo import app
+from user_page import UserPage
+
+import flask
+from selenium import webdriver
+
+
+class UserPageTest(BaseTest):
+
+  """Test user page functionality."""
+
+  def setUp(self):
+    """Setup for test methods."""
+    self.driver = webdriver.Chrome(CHROME_DRIVER_LOCATION)
+    # TODO(eholder) Re-enable this once we have a login module again.
+    # LoginPage(self.driver).Login(self.args)
+    self.context = app.test_request_context()
+    self.context.push()
+
+  def testUserPage(self):
+    """Test the user page."""
+    add_users = (u'Add Users').upper()
+
+    self.driver.get(self.args.server_url + flask.url_for('user_list'))
+    user_page = UserPage(self.driver)
+    self.assertEquals(add_users, user_page.GetAddUserLink().text)
+    self.assertIsNotNone(user_page.GetSidebar())
+
+  def tearDown(self):
+    """Teardown for test methods."""
+    self.driver.quit()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/ui/user_page_test.py
+++ b/tests/ui/user_page_test.py
@@ -24,6 +24,9 @@ class UserPageTest(BaseTest):
 
   def testUserPage(self):
     """Test the user page."""
+    # TODO(eholder): Improve the checks here to be based on something more
+    # robust, such as the presence of element id's or that the page renders
+    # as expected, since this text can change in the future and is not i18ned.
     add_users = (u'Add Users').upper()
 
     self.driver.get(self.args.server_url + flask.url_for('user_list'))

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -33,7 +33,7 @@ def _SendKeysToServer(server, keys):
   #TODO implement
   pass
 
-@app.route('/proxyserver/list')
+@app.route('/proxyserver/')
 @setup_required
 def proxyserver_list():
   proxy_servers = models.ProxyServer.query.all()

--- a/ufo/setup.py
+++ b/ufo/setup.py
@@ -13,7 +13,7 @@ def not_setup():
                                error_text='Please finish configuring this site')
 
 
-@app.route('/setup/', methods=['GET', 'POST'])
+@app.route('/setup', methods=['GET', 'POST'])
 def setup():
   """Handle showing the user the setup page and processing the response"""
   config = get_user_config()

--- a/ufo/setup.py
+++ b/ufo/setup.py
@@ -13,7 +13,7 @@ def not_setup():
                                error_text='Please finish configuring this site')
 
 
-@app.route('/setup', methods=['GET', 'POST'])
+@app.route('/setup/', methods=['GET', 'POST'])
 def setup():
   """Handle showing the user the setup page and processing the response"""
   config = get_user_config()

--- a/ufo/static/sidebar.js
+++ b/ufo/static/sidebar.js
@@ -3,10 +3,10 @@ Polymer({
   ready: function() {
     this.pages = [
     {"href": "/", "text": "Home"},
-    {"href": "/user", "text": "Users"},
-    {"href": "/proxyserver/list", "text": "Proxy Servers"},
-    {"href": "/setup", "text": "Setup"},
-    {"href": "/logout", "text": "Logout"}
+    {"href": "/user/", "text": "Users"},
+    {"href": "/proxyserver/", "text": "Proxy Servers"},
+    {"href": "/setup/", "text": "Setup"},
+    {"href": "/logout/", "text": "Logout"}
     ];
   },
   itemClicked: function(e) {

--- a/ufo/user.py
+++ b/ufo/user.py
@@ -93,7 +93,7 @@ def _MakeInviteCode(user):
 
   return invite_code
 
-@app.route('/user')
+@app.route('/user/')
 @setup_required
 def user_list():
   users = models.User.query.all()

--- a/web_driver.sh
+++ b/web_driver.sh
@@ -11,6 +11,7 @@ ROOT_DIR="$(cd "$(dirname $0)"; pwd)";
 CHROME_DRIVER_VERSION="2.20"
 CHROME_DRIVER_FILE="chromedriver_linux64.zip"
 CHROME_DRIVER_LOCATION="http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/${CHROME_DRIVER_FILE}"
+CHROME_DRIVER_DIR="chrome_driver"
 TEST_DIR="${ROOT_DIR}/tests/ui/"
 
 # A simple bash script to run commands to setup and install all dev
@@ -47,8 +48,8 @@ function installChromeDriver ()
   runAndAssertCmd "unzip $CHROME_DRIVER_FILE"
   runAndAssertCmd "rm $CHROME_DRIVER_FILE"
   runAndAssertCmd "chmod +x chromedriver"
-  runAndAssertCmd "mkdir lib"
-  runAndAssertCmd "mv chromedriver lib/"
+  runAndAssertCmd "mkdir $CHROME_DRIVER_DIR"
+  runAndAssertCmd "mv chromedriver ${CHROME_DRIVER_DIR}/"
 }
 
 function runUITests ()

--- a/web_driver.sh
+++ b/web_driver.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Script to install the chrome web driver locally to run web driver
+# functional tests.
+
+# Get the directory where this script is and set ROOT_DIR to that path. This
+# allows script to be run from different directories but always act on the
+# directory it is within.
+ROOT_DIR="$(cd "$(dirname $0)"; pwd)";
+
+CHROME_DRIVER_VERSION="2.20"
+CHROME_DRIVER_FILE="chromedriver_linux64.zip"
+CHROME_DRIVER_LOCATION="http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/${CHROME_DRIVER_FILE}"
+TEST_DIR="${ROOT_DIR}/tests/ui/"
+
+# A simple bash script to run commands to setup and install all dev
+# dependencies (including non-npm ones)
+function runAndAssertCmd ()
+{
+    echo "Running: $1"
+    echo
+    # We use set -e to make sure this will fail if the command returns an error
+    # code.
+    set -e && cd $ROOT_DIR && eval $1
+}
+
+function runInTestDirAndAssertCmd ()
+{
+  echo "Running: $1"
+  # We use set -e to make sure this will fail if the command returns an error
+  # code.
+  if [ -d  "$TEST_DIR" ]; then
+    echo "In: $TEST_DIR"
+    echo
+    set -e && cd $TEST_DIR && eval $1
+  else
+    echo "In: $ROOT_DIR"
+    echo
+    set -e && cd $ROOT_DIR && eval $1
+  fi
+}
+
+function installChromeDriver ()
+{
+  runAndAssertCmd "pip install -r requirements.txt"
+  runAndAssertCmd "wget $CHROME_DRIVER_LOCATION"
+  runAndAssertCmd "unzip $CHROME_DRIVER_FILE"
+  runAndAssertCmd "rm $CHROME_DRIVER_FILE"
+  runAndAssertCmd "chmod +x chromedriver"
+  runAndAssertCmd "mkdir lib"
+  runAndAssertCmd "mv chromedriver lib/"
+}
+
+function runUITests ()
+{
+  runInTestDirAndAssertCmd "python ui_test_suite.py --server_url='$SERVER_URL' --email='$EMAIL' --password='$PASSWORD'"
+}
+
+function printHelp ()
+{
+  echo
+  echo "Usage: web_driver.sh [install|test]"
+  echo
+  echo "  install   - Installs web driver from chromedriver on googleapis."
+  echo "  test      - Runs the UI test suite."
+  echo
+  echo "The test command takes three additional arguments as follows:"
+  echo "test server_url email password"
+  echo "Example:"
+  echo "./web_driver.sh test https://my-server-staging.appspot.com"
+  echo "ui_tester@mydomain.com your-password-goes-here"
+  echo
+  echo "If you have trouble with permissions while installing, try using sudo."
+  echo "Example: sudo ./web_driver.sh install"
+  echo
+}
+
+
+if [ "$1" == 'install' ]; then
+  installChromeDriver
+elif [ "$1" == 'test' ] && [ $# -eq 4 ]; then
+  SERVER_URL=$2
+  EMAIL=$3
+  PASSWORD=$4
+  runUITests
+else
+  printHelp
+  exit 0
+fi


### PR DESCRIPTION
I was able to migrate these fairly easily. The only piece I left out was the login script since we don't have any login and won't need it yet. I updated the tests to use flask.url_for(some-handler-here) instead of the old paths variables so that should be pretty robust.

These can be run manually as before (see the readme in the old repo for instructions) or with the new script I created. The script can be used both to install web driver (via ./web_driver.sh install) and to run the tests (via ./web_driver.sh test server-url-goes-here email-goes-here password-goes-here). Here is an example:

./web_driver.sh install

./web_driver.sh test http://0.0.0.0:5000 ethan@henrychang.mygbiz.com password-goes-here

Note no trailing / in the url as that will cause a problem. Also, since there is no login yet, the email and password fields don't really matter, but I made the script require them for later, so feel free to enter anything in them for now.

EDIT:
Also note, for the tests to execute properly, you will need a server already running and configured. This does not start up a local server for you, though that is something we could add in the future. This means not only doing python run.py (with & appended if you want it to run headless in the background), but going through the flow to manually setup oauth and domain before running the tests. I personally keep an instance configured locally to test with and then just turn it on as needed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/19)

<!-- Reviewable:end -->
