### PR TITLE
A general error handler to gracefully catch (nearly) all application errors

### DIFF
--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -1,3 +1,4 @@
+import error_handler
 import flask
 from flask.ext import sqlalchemy
 import functools
@@ -12,6 +13,9 @@ if 'DATABASE_URL' in os.environ:
 
 # any instance-specific config the user wants to set, these override everything
 app.config.from_pyfile('application.cfg', silent=True)
+
+# Initialize the error handlings.
+error_handler.init_error_handlers(app)
 
 # TODO(eholder): Move these over to javascript and i18n as appropriate once
 # we've decided how to structure the client side code.
@@ -64,6 +68,9 @@ def get_user_config():
 
   return config
 
+# import setup here
+from setup import SetupNeeded
+
 def setup_required(func):
   """Decorator to handle routes that need setup to have been completed
 
@@ -72,7 +79,7 @@ def setup_required(func):
   def decorated_function(*args, **kwargs):
     config = get_user_config()
     if not config.isConfigured:
-      return flask.redirect(flask.url_for('not_setup'))
+      raise SetupNeeded
     return func(*args, **kwargs)
   return decorated_function
 

--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -14,7 +14,7 @@ if 'DATABASE_URL' in os.environ:
 # any instance-specific config the user wants to set, these override everything
 app.config.from_pyfile('application.cfg', silent=True)
 
-# Initialize the error handlings.
+# Register the error handlers with the app.
 error_handler.init_error_handlers(app)
 
 # TODO(eholder): Move these over to javascript and i18n as appropriate once
@@ -68,7 +68,7 @@ def get_user_config():
 
   return config
 
-# import setup here
+# only import setup here to avoid circular reference
 from setup import SetupNeeded
 
 def setup_required(func):

--- a/ufo/error_handler.py
+++ b/ufo/error_handler.py
@@ -5,8 +5,8 @@ https://goo.gl/OWOa70
 
 One difference here is that we will aim to handle custom exceptions.
 """
+import logging
 
-from flask import current_app
 from flask import Markup
 from flask import render_template
 from flask import request
@@ -20,12 +20,12 @@ ERROR_NAME_500 = 'Internal Server Error'
 
 def handle_error(error):
   """A handler to gracefully handle any application errors.
-  
+
   Args:
     error: Exception object, either python or werkzeug.
   """
   message = 'Request resulted in {}'.format(error)
-  current_app.logger.error(message, exc_info=error)
+  logging.error(message)
 
   if isinstance(error, HTTPException):
     error_code = error.code
@@ -40,8 +40,7 @@ def handle_error(error):
   # one it finds.  This will let us create specific error pages
   # for errors where we can provide the user some additional help.
   # (Like a 404, for example).
-  templates_to_try = ['{}_error.html'.format(error_code),
-                      'error.html']
+  templates_to_try = ['{}_error.html'.format(error_code), 'error.html']
   return render_template(templates_to_try,
                          error_code=error_code,
                          error_name=error_name,
@@ -49,7 +48,7 @@ def handle_error(error):
 
 def init_error_handlers(app):
   """Register all the default HTTP error handlers with flask.
-  
+
   Args:
     app: flask app object
   """

--- a/ufo/error_handler.py
+++ b/ufo/error_handler.py
@@ -1,0 +1,59 @@
+"""An error handler module to grancefully handle all application errors.
+
+The work here is based on the most-excellent flask development doc below.
+https://goo.gl/OWOa70
+
+One difference here is that we will aim to handle custom exceptions.
+"""
+
+from flask import current_app
+from flask import Markup
+from flask import render_template
+from flask import request
+from werkzeug.exceptions import default_exceptions
+from werkzeug.exceptions import HTTPException
+
+
+ERROR_CODE_500 = '500'
+ERROR_NAME_500 = 'Internal Server Error'
+
+
+def handle_error(error):
+  """A handler to gracefully handle any application errors.
+  
+  Args:
+    error: Exception object, either python or werkzeug.
+  """
+  msg = 'Request resulted in {}'.format(error)
+  current_app.logger.error(msg, exc_info=error)
+
+  if isinstance(error, HTTPException):
+    error_code = error.code
+    error_name = error.name
+    error_text = error.get_description(request.environ)
+  else:
+    error_code = ERROR_CODE_500
+    error_name = ERROR_NAME_500
+    error_text = error.message
+
+  # Flask supports looking up multiple templates and rendering the first
+  # one it finds.  This will let us create specific error pages
+  # for errors where we can provide the user some additional help.
+  # (Like a 404, for example).
+  templates_to_try = ['{}_error.html'.format(error_code),
+                      'error.html']
+  return render_template(templates_to_try,
+                         error_code=error_code,
+                         error_name=error_name,
+                         error_text=Markup(error_text))
+
+def init_error_handlers(app):
+  """Register all the default HTTP error handlers with flask.
+  
+  Args:
+    app: flask app object
+  """
+
+  for exception in default_exceptions:
+    app.register_error_handler(exception, handle_error)
+  app.register_error_handler(Exception, handle_error)

--- a/ufo/error_handler.py
+++ b/ufo/error_handler.py
@@ -9,7 +9,7 @@ import logging
 
 from flask import render_template
 from flask import request
-import werkzeug.exceptions
+from werkzeug import exceptions
 
 
 def handle_error(error):
@@ -20,8 +20,8 @@ def handle_error(error):
   """
   logging.error('Request resulted in {}'.format(error))
 
-  if not isinstance(error, werkzeug.exceptions.HTTPException):
-    error = werkzeug.exceptions.InternalServerError(error.message)
+  if not isinstance(error, exceptions.HTTPException):
+    error = exceptions.InternalServerError(error.message)
   
   # Flask supports looking up multiple templates and rendering the first
   # one it finds.  This will let us create specific error pages
@@ -37,6 +37,6 @@ def init_error_handlers(app):
     app: flask app object
   """
 
-  for exception in werkzeug.exceptions.default_exceptions:
+  for exception in exceptions.default_exceptions:
     app.register_error_handler(exception, handle_error)
   app.register_error_handler(Exception, handle_error)

--- a/ufo/error_handler.py
+++ b/ufo/error_handler.py
@@ -24,8 +24,8 @@ def handle_error(error):
   Args:
     error: Exception object, either python or werkzeug.
   """
-  msg = 'Request resulted in {}'.format(error)
-  current_app.logger.error(msg, exc_info=error)
+  message = 'Request resulted in {}'.format(error)
+  current_app.logger.error(message, exc_info=error)
 
   if isinstance(error, HTTPException):
     error_code = error.code

--- a/ufo/error_handler.py
+++ b/ufo/error_handler.py
@@ -1,4 +1,4 @@
-"""An error handler module to grancefully handle all application errors.
+"""An error handler module to gracefully handle all application errors.
 
 The work here is based on the most-excellent flask development doc below.
 https://goo.gl/OWOa70

--- a/ufo/error_handler_test.py
+++ b/ufo/error_handler_test.py
@@ -1,0 +1,57 @@
+from mock import MagicMock
+from mock import patch
+
+import base_test
+import error_handler
+from setup import SetupNeeded
+
+import flask
+from werkzeug.exceptions import default_exceptions
+from werkzeug.exceptions import NotFound
+
+
+class ErrorHandlerTest(base_test.BaseTest):
+  """Test error handler class functionalities."""
+
+  def setUp(self):
+    """Setup test app on which to call handlers and db to query."""
+    super(ErrorHandlerTest, self).setUp()
+
+  def testDefaultHTTPErrorHandlersAreRegistered(self):
+    """Test the default HTTP error handlers are registered."""
+    app_error_handlers = self.client.application.error_handler_spec[None]
+    for error_code in default_exceptions:
+      self.assertTrue(error_code in app_error_handlers)
+
+  def testCustomErrorIsHandled(self):
+    """Test custom error handler is registered.
+    
+    setup_config() is not called, thus SetupNeeded error should be thrown.
+    TODO(henry): see if this should be moved to setup_test.py
+    """
+    resp = self.client.get(flask.url_for('proxyserver_list'))
+
+    self.assertTrue(error_handler.ERROR_CODE_500 in resp.data)
+    self.assertTrue(error_handler.ERROR_NAME_500 in resp.data)
+    self.assertTrue(SetupNeeded.message in resp.data)
+
+  def testErrorHandlerCanProcessHTTPError(self):
+    """Test error handler can process HTTP error."""
+    error_404 = NotFound()
+    resp = error_handler.handle_error(error_404)
+
+    self.assertTrue(str(error_404.code) in resp)
+    self.assertTrue(error_404.name in resp)
+
+  def testErrorHandlerCanProcessCustomError(self):
+    """Test error handler can process custom error."""
+    setup_needed = SetupNeeded()
+    resp = error_handler.handle_error(setup_needed)
+
+    self.assertTrue(error_handler.ERROR_CODE_500 in resp)
+    self.assertTrue(error_handler.ERROR_NAME_500 in resp)
+    self.assertTrue(setup_needed.message in resp)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/ufo/error_handler_test.py
+++ b/ufo/error_handler_test.py
@@ -25,7 +25,7 @@ class ErrorHandlerTest(base_test.BaseTest):
 
   def testCustomErrorIsHandled(self):
     """Test custom error handler is registered.
-    
+
     setup_config() is not called, thus SetupNeeded error should be thrown.
     TODO(henry): see if this should be moved to setup_test.py
     """

--- a/ufo/error_handler_test.py
+++ b/ufo/error_handler_test.py
@@ -6,7 +6,7 @@ import error_handler
 from setup import SetupNeeded
 
 import flask
-import werkzeug.exceptions
+from werkzeug import exceptions
 
 
 class ErrorHandlerTest(base_test.BaseTest):
@@ -19,7 +19,7 @@ class ErrorHandlerTest(base_test.BaseTest):
   def testDefaultHTTPErrorHandlersAreRegistered(self):
     """Test the default HTTP error handlers are registered."""
     app_error_handlers = self.client.application.error_handler_spec[None]
-    for error_code in werkzeug.exceptions.default_exceptions:
+    for error_code in exceptions.default_exceptions:
       self.assertTrue(error_code in app_error_handlers)
 
   def testUnknowExceptionTypesAreHandled(self):
@@ -27,7 +27,7 @@ class ErrorHandlerTest(base_test.BaseTest):
 
     setup_config() is not called, thus SetupNeeded error should be thrown.
     """
-    setup_needed_error = werkzeug.exceptions.InternalServerError(
+    setup_needed_error = exceptions.InternalServerError(
         SetupNeeded.message)
     resp = self.client.get(flask.url_for('proxyserver_list'))
 
@@ -37,7 +37,7 @@ class ErrorHandlerTest(base_test.BaseTest):
 
   def testErrorHandlerCanProcessHTTPError(self):
     """Test error handler can process HTTP error."""
-    error_404 = werkzeug.exceptions.NotFound()
+    error_404 = exceptions.NotFound()
     resp = error_handler.handle_error(error_404)
 
     self.assertTrue(str(error_404.code) in resp)
@@ -46,7 +46,7 @@ class ErrorHandlerTest(base_test.BaseTest):
   def testErrorHandlerCanProcessCustomError(self):
     """Test error handler can process custom error."""
     setup_needed_error = SetupNeeded()
-    werkzeug_error = werkzeug.exceptions.InternalServerError(
+    werkzeug_error = exceptions.InternalServerError(
         SetupNeeded.message)
 
     resp = error_handler.handle_error(setup_needed_error)

--- a/ufo/setup.py
+++ b/ufo/setup.py
@@ -7,10 +7,9 @@ import oauth2client
 
 from googleapiclient import discovery
 
-@app.route('/not_setup/')
-def not_setup():
-  return flask.render_template('error.html',
-                               error_text='Please finish configuring this site')
+
+class SetupNeeded(Exception):
+  message = 'Please finish configuring this site'
 
 
 @app.route('/setup/', methods=['GET', 'POST'])

--- a/ufo/setup.py
+++ b/ufo/setup.py
@@ -9,6 +9,7 @@ from googleapiclient import discovery
 
 
 class SetupNeeded(Exception):
+  code = 500
   message = 'Please finish configuring this site'
 
 

--- a/ufo/templates/error.html
+++ b/ufo/templates/error.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block body %}
   <h2>Error</h2>
-  <p>{{ error_code }} - {{ error_name }}</p>
-  <p>{{ error_text }}</p>
+  <p>{{ error.code }} - {{ error.name }}</p>
+  <p>{{ error.description }}</p>
 {% endblock %}

--- a/ufo/templates/error.html
+++ b/ufo/templates/error.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% block body %}
   <h2>Error</h2>
+  <p>{{ error_code }} - {{ error_name }}</p>
   <p>{{ error_text }}</p>
 {% endblock %}


### PR DESCRIPTION
- The goal here is to have a mechanism to gracefully catch (nearly) all the application errors.
- Other specifics, e.g. how exactly to handle the errors, are TBD, pending UX mocks (i.e. html, butterbars, polymer toasts, etc).
- The work here is based on the guide at https://goo.gl/OWOa70, but improved to allow custom exceptions to be handled.
- Added a custom SetupNeeded error, thus making /not_setup/ routing to be unnecessary.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/21)

<!-- Reviewable:end -->
