### PR TITLE
Fix bug in proxy server list template where only the first card is displayed.

### DIFF
--- a/ufo/templates/proxy_server.html
+++ b/ufo/templates/proxy_server.html
@@ -16,7 +16,7 @@
       <div class="card-content">
         <p>{{ proxy_server.ip_address }}</p>
         <paper-button onclick="toggleCollapse('collapse-{{loop.index}}')">Show/hide SSH Keys</paper-button>
-        <iron-collapse id="collapse-{{loop.index}}"><div>
+        <iron-collapse id="collapse-{{loop.index}}">
           <h3>Public Key (for verification)</h3>
           <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{proxy_server.public_key}}</pre>
 


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/25)

<!-- Reviewable:end -->
