### PR TITLE
Create Managed Chrome Policy from the Management Server

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "paper-listbox": "PolymerElements/paper-listbox#~1.1.0",
     "paper-menu": "PolymerElements/paper-menu#~1.2.1",
     "paper-tabs": "PolymerElements/paper-tabs#~1.2.4",
+    "paper-toggle-button": "PolymerElements/paper-toggle-button#~1.0.14",
     "paper-toolbar": "PolymerElements/paper-toolbar#~1.1.2"
   }
 }

--- a/tests/ui/sidebar.py
+++ b/tests/ui/sidebar.py
@@ -16,6 +16,7 @@ class Sidebar(BaseDriver):
   HOME_LINK = (By.ID, 'Home')
   USERS_LINK = (By.ID, 'Users')
   PROXY_SERVERS_LINK = (By.ID, 'Proxy Servers')
+  CHROME_POLICY_LINK = (By.ID, 'Chrome Policy')
   SETUP_LINK = (By.ID, 'Setup')
   LOGOUT_LINK = (By.ID, 'Logout')
 

--- a/tests/ui/sidebar_test.py
+++ b/tests/ui/sidebar_test.py
@@ -39,6 +39,10 @@ class SidebarTest(BaseTest):
     self.assertEquals(flask.url_for('proxyserver_list'),
                       proxy_servers_link.get_attribute('data-href'))
 
+    chrome_policy_link = sidebar.GetLink(sidebar.CHROME_POLICY_LINK)
+    self.assertEquals(flask.url_for('chrome_policy'),
+                      chrome_policy_link.get_attribute('data-href'))
+
     setup_link = sidebar.GetLink(sidebar.SETUP_LINK)
     self.assertEquals(flask.url_for('setup'),
                       setup_link.get_attribute('data-href'))

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -1,0 +1,38 @@
+"""The module for generating and outputing chrome policy."""
+
+from . import app, setup_required
+
+import flask
+import json
+
+import models
+
+
+def _MakeChromePolicyJson():
+  """Generate the json string of chrome policy based on values in the database.
+
+  This policy string has the following form:
+
+  Returns:
+    A json string of current chrome policy.
+  """
+  proxy_servers = models.ProxyServer.query.all()
+  proxy_server_public_keys = [s._MakePublicKey() for s in proxy_servers]
+
+  config = models.Config.query.get(0)
+
+  policy_dictionary = {
+      "proxy_server_keys": proxy_server_public_keys,
+      "enforce_proxy_server_validity": config.proxy_server_validity,
+      "enforce_network_jail": config.network_jail_until_google_auth,
+  }
+
+  return json.dumps(policy_dictionary)
+
+
+@app.route('/chromepolicy/')
+@setup_required
+def chrome_policy():
+  policy_json = _MakeChromePolicyJson()
+
+  return flask.render_template('chrome_policy.html', policy_json=policy_json)

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -36,3 +36,9 @@ def chrome_policy():
   policy_json = _MakeChromePolicyJson()
 
   return flask.render_template('chrome_policy.html', policy_json=policy_json)
+
+
+@app.route('/chromepolicy/download/')
+@setup_required
+def chrome_policy_download():
+  return _MakeChromePolicyJson()

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -5,7 +5,7 @@ from . import app, setup_required
 import flask
 import json
 
-import models
+import ufo.models
 
 
 def _make_chrome_policy_json():
@@ -16,10 +16,10 @@ def _make_chrome_policy_json():
   Returns:
     A json string of current chrome policy.
   """
-  proxy_servers = models.ProxyServer.query.all()
-  proxy_server_public_keys = [s._MakePublicKey() for s in proxy_servers]
+  proxy_servers = ufo.models.ProxyServer.query.all()
+  proxy_server_public_keys = [s.make_public_key() for s in proxy_servers]
 
-  config = models.Config.query.get(0)
+  config = ufo.models.Config.query.get(0)
 
   policy_dictionary = {
       "proxy_server_keys": proxy_server_public_keys,
@@ -39,7 +39,7 @@ def display_chrome_policy():
     The rendered chrom_policy.html template with policy values as variables.
   """
   policy_json = _make_chrome_policy_json()
-  config = models.Config.query.get(0)
+  config = ufo.models.Config.query.get(0)
 
   return flask.render_template(
       'chrome_policy.html', policy_json=policy_json,
@@ -68,7 +68,7 @@ def edit_policy_config():
     A redirect back to display chrome policy with will display the new values.
   """
 
-  config = models.Config.query.get(0)
+  config = ufo.models.Config.query.get(0)
 
   # TODO(eholder): The Polymer html for sending toggle button values as inputs
   # really sucks. I basically have to parse it out manually in JS then set it

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -75,19 +75,10 @@ def edit_policy_config():
 
   config = ufo.get_user_config()
 
-  # TODO(eholder): The Polymer html for sending toggle button values as inputs
-  # really sucks. I basically have to parse it out manually in JS then set it
-  # to a hidden input value. If we used iron-form, that may help with setting
-  # those as inputs on its own. That introduces a problem with refreshing the
-  # page on response or writing the response back into the UI for an update...
-  # TODO(eholder): There has to be a better way to convert strings to bools...
   proxy_server_string = flask.request.form.get('enforce_proxy_server_validity')
   network_jail_string = flask.request.form.get('enforce_network_jail')
-
-  config.proxy_server_validity = (proxy_server_string == 'true' or
-                                  proxy_server_string == 'True')
-  config.network_jail_until_google_auth = (network_jail_string == 'true' or
-                                           network_jail_string == 'True')
+  config.proxy_server_validity = json.loads(proxy_server_string)
+  config.network_jail_until_google_auth = json.loads(network_jail_string)
 
   config.save()
 

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -25,7 +25,6 @@ def _make_chrome_policy_json():
   policy_dictionary = {
       "proxy_server_keys": proxy_server_public_keys,
       "enforce_proxy_server_validity": config.proxy_server_validity,
-      "enforce_network_jail": config.network_jail_until_google_auth,
   }
 
   return json.dumps(policy_dictionary)
@@ -69,6 +68,10 @@ def edit_policy_config():
   Returns:
     A redirect back to display chrome policy with will display the new values.
   """
+  # TODO(eholder): Move the display of config values and the edit handlers to
+  # something more sensible once UI review tells us what that should be. I'm
+  # envisioning a settings or options page which is underneath the overall
+  # Setup link. For now, I just want these settings to be edittable somewhere.
 
   config = ufo.get_user_config()
 

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -34,11 +34,40 @@ def _MakeChromePolicyJson():
 @setup_required
 def chrome_policy():
   policy_json = _MakeChromePolicyJson()
+  config = models.Config.query.get(0)
 
-  return flask.render_template('chrome_policy.html', policy_json=policy_json)
+  return flask.render_template(
+      'chrome_policy.html', policy_json=policy_json,
+      enforce_proxy_server_validity=config.proxy_server_validity,
+      enforce_network_jail=config.network_jail_until_google_auth)
 
 
 @app.route('/chromepolicy/download/')
 @setup_required
 def chrome_policy_download():
   return _MakeChromePolicyJson()
+
+@app.route('/chromepolicy/edit', methods=['POST'])
+@setup_required
+def edit_policy_config():
+  """Post the form for editing the policy config values."""
+
+  config = models.Config.query.get(0)
+
+  # TODO(eholder): The Polymer html for sending toggle button values as inputs
+  # really sucks. I basically have to parse it out manually in JS then set it
+  # to a hidden input value. If we used iron-form, that may help with setting
+  # those as inputs on its own. That introduces a problem with refreshing the
+  # page on response or writing the response back into the UI for an update...
+  # TODO(eholder): There has to be a better way to convert strings to bools...
+  proxy_server_string = flask.request.form.get('enforce_proxy_server_validity')
+  network_jail_string = flask.request.form.get('enforce_network_jail')
+
+  config.proxy_server_validity = (proxy_server_string == 'true' or
+                                  proxy_server_string == 'True')
+  config.network_jail_until_google_auth = (network_jail_string == 'true' or
+                                           network_jail_string == 'True')
+
+  config.save()
+
+  return flask.redirect(flask.url_for('chrome_policy'))

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -1,7 +1,5 @@
 """The module for generating and outputing chrome policy."""
 
-from . import app, setup_required
-
 import flask
 import json
 
@@ -30,8 +28,8 @@ def _make_chrome_policy_json():
   return json.dumps(policy_dictionary)
 
 
-@app.route('/chromepolicy/')
-@setup_required
+@ufo.app.route('/chromepolicy/')
+@ufo.setup_required
 def display_chrome_policy():
   """Renders the current chrome policy as json and editable values.
 
@@ -47,8 +45,8 @@ def display_chrome_policy():
       enforce_network_jail=config.network_jail_until_google_auth)
 
 
-@app.route('/chromepolicy/download/')
-@setup_required
+@ufo.app.route('/chromepolicy/download/')
+@ufo.setup_required
 def download_chrome_policy():
   """Outputs the managed chrome policy in json form for downloading as a file.
 
@@ -58,8 +56,8 @@ def download_chrome_policy():
   return flask.Response(_make_chrome_policy_json(),
                         mimetype='application/json')
 
-@app.route('/chromepolicy/edit', methods=['POST'])
-@setup_required
+@ufo.app.route('/chromepolicy/edit', methods=['POST'])
+@ufo.setup_required
 def edit_policy_config():
   """Receives the posted form for editing the policy config values.
 

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -5,7 +5,8 @@ from . import app, setup_required
 import flask
 import json
 
-import ufo.models
+import ufo
+from ufo import models
 
 
 def _make_chrome_policy_json():
@@ -16,10 +17,10 @@ def _make_chrome_policy_json():
   Returns:
     A json string of current chrome policy.
   """
-  proxy_servers = ufo.models.ProxyServer.query.all()
-  proxy_server_public_keys = [s.make_public_key() for s in proxy_servers]
+  proxy_servers = models.ProxyServer.query.all()
+  proxy_server_public_keys = [s.get_public_key_as_authorization_file_string() for s in proxy_servers]
 
-  config = ufo.models.Config.query.get(0)
+  config = ufo.get_user_config()
 
   policy_dictionary = {
       "proxy_server_keys": proxy_server_public_keys,
@@ -39,7 +40,7 @@ def display_chrome_policy():
     The rendered chrom_policy.html template with policy values as variables.
   """
   policy_json = _make_chrome_policy_json()
-  config = ufo.models.Config.query.get(0)
+  config = ufo.get_user_config()
 
   return flask.render_template(
       'chrome_policy.html', policy_json=policy_json,
@@ -55,7 +56,8 @@ def download_chrome_policy():
   Returns:
     A json file of the current managed chrome policy.
   """
-  return _make_chrome_policy_json()
+  return flask.Response(_make_chrome_policy_json(),
+                        mimetype='application/json')
 
 @app.route('/chromepolicy/edit', methods=['POST'])
 @setup_required
@@ -68,7 +70,7 @@ def edit_policy_config():
     A redirect back to display chrome policy with will display the new values.
   """
 
-  config = ufo.models.Config.query.get(0)
+  config = ufo.get_user_config()
 
   # TODO(eholder): The Polymer html for sending toggle button values as inputs
   # really sucks. I basically have to parse it out manually in JS then set it

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -9,7 +9,7 @@ import models
 
 
 def _MakeChromePolicyJson():
-  """Generate the json string of chrome policy based on values in the database.
+  """Generates the json string of chrome policy based on values in the db.
 
   This policy string has the following form:
 
@@ -32,7 +32,12 @@ def _MakeChromePolicyJson():
 
 @app.route('/chromepolicy/')
 @setup_required
-def chrome_policy():
+def display_chrome_policy():
+  """Renders the current chrome policy as json and editable values.
+
+  Returns:
+    The rendered chrom_policy.html template with policy values as variables.
+  """
   policy_json = _MakeChromePolicyJson()
   config = models.Config.query.get(0)
 
@@ -44,13 +49,24 @@ def chrome_policy():
 
 @app.route('/chromepolicy/download/')
 @setup_required
-def chrome_policy_download():
+def download_chrome_policy():
+  """Outputs the managed chrome policy in json form for downloading as a file.
+
+  Returns:
+    A json file of the current managed chrome policy.
+  """
   return _MakeChromePolicyJson()
 
 @app.route('/chromepolicy/edit', methods=['POST'])
 @setup_required
 def edit_policy_config():
-  """Post the form for editing the policy config values."""
+  """Receives the posted form for editing the policy config values.
+
+  The new policy config values are stored in the database.
+
+  Returns:
+    A redirect back to display chrome policy with will display the new values.
+  """
 
   config = models.Config.query.get(0)
 
@@ -70,4 +86,4 @@ def edit_policy_config():
 
   config.save()
 
-  return flask.redirect(flask.url_for('chrome_policy'))
+  return flask.redirect(flask.url_for('display_chrome_policy'))

--- a/ufo/chrome_policy.py
+++ b/ufo/chrome_policy.py
@@ -8,7 +8,7 @@ import json
 import models
 
 
-def _MakeChromePolicyJson():
+def _make_chrome_policy_json():
   """Generates the json string of chrome policy based on values in the db.
 
   This policy string has the following form:
@@ -38,7 +38,7 @@ def display_chrome_policy():
   Returns:
     The rendered chrom_policy.html template with policy values as variables.
   """
-  policy_json = _MakeChromePolicyJson()
+  policy_json = _make_chrome_policy_json()
   config = models.Config.query.get(0)
 
   return flask.render_template(
@@ -55,7 +55,7 @@ def download_chrome_policy():
   Returns:
     A json file of the current managed chrome policy.
   """
-  return _MakeChromePolicyJson()
+  return _make_chrome_policy_json()
 
 @app.route('/chromepolicy/edit', methods=['POST'])
 @setup_required

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -19,7 +19,12 @@ class ChromePolicyTest(base_test.BaseTest):
 
   @mock.patch('flask.render_template')
   def testChromePolicyRenderTemplate(self, mock_render_template):
-    """Test the chrome policy handler renders the page."""
+    """Test the chrome policy handler renders the page.
+
+    Args:
+      mock_render_template: A mocked instance of flask.render_template on
+                            which to assert about call arguments.
+    """
     mock_render_template.return_value = ''
     self.client.get(flask.url_for('display_chrome_policy'))
 

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -47,8 +47,8 @@ class ChromePolicyTest(base_test.BaseTest):
     initial_proxy_server_config = config.proxy_server_validity
     initial_network_jail_config = config.network_jail_until_google_auth
     data_to_post = {
-        'enforce_proxy_server_validity': str(not initial_proxy_server_config),
-        'enforce_network_jail': str(not initial_network_jail_config),
+        'enforce_proxy_server_validity': json.dumps(not initial_proxy_server_config),
+        'enforce_network_jail': json.dumps(not initial_network_jail_config),
     }
 
     resp = self.client.post(flask.url_for('edit_policy_config'),

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -23,6 +23,10 @@ class ChromePolicyTest(base_test.BaseTest):
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('chrome_policy.html', args[0])
+    json_data = json.loads(kwargs['policy_json'])
+    self.assertIn('proxy_server_keys', json_data)
+    self.assertIn('enforce_proxy_server_validity', json_data)
+    self.assertIn('enforce_network_jail', json_data)
 
   def testChromePolicyDownload(self):
     """Test the chrome policy download handler downloads json."""

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -5,11 +5,11 @@ import json
 import mock
 import unittest
 
-import ufo.base_test
-import ufo.models
+import ufo
+from ufo import base_test
 
 
-class ChromePolicyTest(ufo.base_test.BaseTest):
+class ChromePolicyTest(base_test.BaseTest):
   """Test chrome policy functionality."""
 
   def setUp(self):
@@ -43,7 +43,7 @@ class ChromePolicyTest(ufo.base_test.BaseTest):
 
   def testEditValuesForPolicyConfig(self):
     """Test posting with modified policy config values updates in the db."""
-    config = ufo.models.Config.query.get(0)
+    config = ufo.get_user_config()
     initial_proxy_server_config = config.proxy_server_validity
     initial_network_jail_config = config.network_jail_until_google_auth
     data_to_post = {
@@ -54,7 +54,7 @@ class ChromePolicyTest(ufo.base_test.BaseTest):
     resp = self.client.post(flask.url_for('edit_policy_config'),
                             data=data_to_post, follow_redirects=False)
 
-    updated_config = ufo.models.Config.query.get(0)
+    updated_config = ufo.get_user_config()
     self.assertEqual(not initial_proxy_server_config,
                      updated_config.proxy_server_validity)
     self.assertEqual(not initial_network_jail_config,

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -19,7 +19,7 @@ class ChromePolicyTest(base_test.BaseTest):
   def testChromePolicyRenderTemplate(self, mock_render_template):
     """Test the chrome policy handler renders the page."""
     mock_render_template.return_value = ''
-    resp = self.client.get(flask.url_for('chrome_policy'))
+    resp = self.client.get(flask.url_for('display_chrome_policy'))
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('chrome_policy.html', args[0])
@@ -32,7 +32,7 @@ class ChromePolicyTest(base_test.BaseTest):
 
   def testChromePolicyDownload(self):
     """Test the chrome policy download handler downloads json."""
-    resp = self.client.get(flask.url_for('chrome_policy_download'))
+    resp = self.client.get(flask.url_for('download_chrome_policy'))
 
     json_data = json.loads(resp.data)
     self.assertIn('proxy_server_keys', json_data)
@@ -57,7 +57,7 @@ class ChromePolicyTest(base_test.BaseTest):
                      updated_config.proxy_server_validity)
     self.assertEqual(not initial_network_jail_config,
                      updated_config.network_jail_until_google_auth)
-    self.assert_redirects(resp, flask.url_for('chrome_policy'))
+    self.assert_redirects(resp, flask.url_for('display_chrome_policy'))
 
 if __name__ == '__main__':
   unittest.main()

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -1,0 +1,37 @@
+
+import flask
+import json
+import mock
+
+import base_test
+import models
+import chrome_policy
+
+class ChromePolicyTest(base_test.BaseTest):
+  """Test chrome policy functionality."""
+
+  def setUp(self):
+    """Setup test app on which to call handlers and db to query."""
+    super(ChromePolicyTest, self).setUp()
+    super(ChromePolicyTest, self).setup_config()
+
+  @mock.patch('flask.render_template')
+  def testChromePolicyRenderTemplate(self, mock_render_template):
+    """Test the chrome policy handler renders the page."""
+    mock_render_template.return_value = ''
+    resp = self.client.get(flask.url_for('chrome_policy'))
+
+    args, kwargs = mock_render_template.call_args
+    self.assertEquals('chrome_policy.html', args[0])
+
+  def testChromePolicyDownload(self):
+    """Test the chrome policy download handler downloads json."""
+    resp = self.client.get(flask.url_for('chrome_policy_download'))
+
+    json_data = json.loads(resp.data)
+    self.assertIn('proxy_server_keys', json_data)
+    self.assertIn('enforce_proxy_server_validity', json_data)
+    self.assertIn('enforce_network_jail', json_data)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -28,7 +28,7 @@ class ChromePolicyTest(base_test.BaseTest):
     json_data = json.loads(kwargs['policy_json'])
     self.assertIn('proxy_server_keys', json_data)
     self.assertIn('enforce_proxy_server_validity', json_data)
-    self.assertIn('enforce_network_jail', json_data)
+    self.assertNotIn('enforce_network_jail', json_data)
     self.assertIn('enforce_proxy_server_validity', kwargs)
     self.assertIn('enforce_network_jail', kwargs)
 
@@ -39,7 +39,7 @@ class ChromePolicyTest(base_test.BaseTest):
     json_data = json.loads(resp.data)
     self.assertIn('proxy_server_keys', json_data)
     self.assertIn('enforce_proxy_server_validity', json_data)
-    self.assertIn('enforce_network_jail', json_data)
+    self.assertNotIn('enforce_network_jail', json_data)
 
   def testEditValuesForPolicyConfig(self):
     """Test posting with modified policy config values updates in the db."""

--- a/ufo/chrome_policy_test.py
+++ b/ufo/chrome_policy_test.py
@@ -1,13 +1,15 @@
+"""Test chrome policy module functionality."""
 
 import flask
 import json
 import mock
+import unittest
 
-import base_test
-import models
-import chrome_policy
+import ufo.base_test
+import ufo.models
 
-class ChromePolicyTest(base_test.BaseTest):
+
+class ChromePolicyTest(ufo.base_test.BaseTest):
   """Test chrome policy functionality."""
 
   def setUp(self):
@@ -19,7 +21,7 @@ class ChromePolicyTest(base_test.BaseTest):
   def testChromePolicyRenderTemplate(self, mock_render_template):
     """Test the chrome policy handler renders the page."""
     mock_render_template.return_value = ''
-    resp = self.client.get(flask.url_for('display_chrome_policy'))
+    self.client.get(flask.url_for('display_chrome_policy'))
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('chrome_policy.html', args[0])
@@ -41,7 +43,7 @@ class ChromePolicyTest(base_test.BaseTest):
 
   def testEditValuesForPolicyConfig(self):
     """Test posting with modified policy config values updates in the db."""
-    config = models.Config.query.get(0)
+    config = ufo.models.Config.query.get(0)
     initial_proxy_server_config = config.proxy_server_validity
     initial_network_jail_config = config.network_jail_until_google_auth
     data_to_post = {
@@ -52,7 +54,7 @@ class ChromePolicyTest(base_test.BaseTest):
     resp = self.client.post(flask.url_for('edit_policy_config'),
                             data=data_to_post, follow_redirects=False)
 
-    updated_config = models.Config.query.get(0)
+    updated_config = ufo.models.Config.query.get(0)
     self.assertEqual(not initial_proxy_server_config,
                      updated_config.proxy_server_validity)
     self.assertEqual(not initial_network_jail_config,

--- a/ufo/models.py
+++ b/ufo/models.py
@@ -141,4 +141,4 @@ class ProxyServer(Model):
     public_key = ssh_client.SSHClient.public_key_data_to_object(
         self.host_public_key_type,
         self.host_public_key)
-    return public_key
+    return public_key.get_name() + ' ' + public_key.get_base64()

--- a/ufo/models.py
+++ b/ufo/models.py
@@ -132,7 +132,7 @@ class ProxyServer(Model):
     self.host_public_key_type = host_key_entry.key.get_name()
     self.host_public_key = host_key_entry.key.asbytes()
 
-  def _MakePublicKey(self):
+  def make_public_key(self):
     """Creates an output-able string of the public key for the server.
 
     Returns:

--- a/ufo/models.py
+++ b/ufo/models.py
@@ -132,7 +132,7 @@ class ProxyServer(Model):
     self.host_public_key_type = host_key_entry.key.get_name()
     self.host_public_key = host_key_entry.key.asbytes()
 
-  def make_public_key(self):
+  def get_public_key_as_authorization_file_string(self):
     """Creates an output-able string of the public key for the server.
 
     Returns:

--- a/ufo/models.py
+++ b/ufo/models.py
@@ -44,6 +44,8 @@ class Config(Model):
   credentials = db.Column(db.Text())
   domain = db.Column(db.String(LONG_STRING_LENGTH))
   dv_content = db.Column(db.String(LONG_STRING_LENGTH))
+  proxy_server_validity = db.Column(db.Boolean(), default=False)
+  network_jail_until_google_auth = db.Column(db.Boolean(), default=False)
 
 
 class User(Model):
@@ -129,3 +131,14 @@ class ProxyServer(Model):
 
     self.host_public_key_type = host_key_entry.key.get_name()
     self.host_public_key = host_key_entry.key.asbytes()
+
+  def _MakePublicKey(self):
+    """Creates an output-able string of the public key for the server.
+
+    Returns:
+      A string of the public key for this proxy server.
+    """
+    public_key = ssh_client.SSHClient.public_key_data_to_object(
+        self.host_public_key_type,
+        self.host_public_key)
+    return public_key

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -51,7 +51,7 @@ def _GetViewDataFromProxyServer(server):
     "id": server.id,
     "name": server.name,
     "ip_address": server.ip_address,
-    "public_key": server._MakePublicKey(),
+    "public_key": server.make_public_key(),
     "private_key": private_key_text,
     }
 

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -40,9 +40,7 @@ def _SendKeysToServer(server, keys):
   client.close()
 
 def _GetViewDataFromProxyServer(server):
-  public_key = ssh_client.SSHClient.public_key_data_to_object(
-      server.host_public_key_type,
-      server.host_public_key)
+  public_key = server._MakePublicKey()
   private_key = ssh_client.SSHClient.private_key_data_to_object(
       server.ssh_private_key_type,
       server.ssh_private_key)

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -51,7 +51,7 @@ def _GetViewDataFromProxyServer(server):
     "id": server.id,
     "name": server.name,
     "ip_address": server.ip_address,
-    "public_key": server.make_public_key(),
+    "public_key": server.get_public_key_as_authorization_file_string(),
     "private_key": private_key_text,
     }
 

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -40,7 +40,6 @@ def _SendKeysToServer(server, keys):
   client.close()
 
 def _GetViewDataFromProxyServer(server):
-  public_key = server._MakePublicKey()
   private_key = ssh_client.SSHClient.private_key_data_to_object(
       server.ssh_private_key_type,
       server.ssh_private_key)
@@ -52,7 +51,7 @@ def _GetViewDataFromProxyServer(server):
     "id": server.id,
     "name": server.name,
     "ip_address": server.ip_address,
-    "public_key": public_key.get_name() + ' ' + public_key.get_base64(),
+    "public_key": server._MakePublicKey(),
     "private_key": private_key_text,
     }
 

--- a/ufo/routes.py
+++ b/ufo/routes.py
@@ -11,3 +11,4 @@ def landing():
 import setup # handlers for /setup
 import user # handlers for /user
 import proxy_server # handlers for /proxy_server
+import chrome_policy # handlers for /chrome_policy

--- a/ufo/static/collapseButton.html
+++ b/ufo/static/collapseButton.html
@@ -1,0 +1,16 @@
+<link rel="import" href="bower_components/iron-collapse/iron-collapse.html" />
+<link rel="import" href="bower_components/paper-button/paper-button.html" />
+<!-- <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
+<link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" /> -->
+
+<dom-module id="ufo-collapse-button">
+    <template>
+        <paper-button on-tap="toggleCollapse">{{buttonText}}</paper-button>
+        <iron-collapse class="collapse">
+          <h3>{{label}}</h3>
+          <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{collapseText}}</pre>
+        </iron-collapse>
+    </template>
+
+    <script src="collapseButton.js"></script>
+</dom-module>

--- a/ufo/static/collapseButton.html
+++ b/ufo/static/collapseButton.html
@@ -1,7 +1,5 @@
 <link rel="import" href="bower_components/iron-collapse/iron-collapse.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
-<!-- <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
-<link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" /> -->
 
 <dom-module id="ufo-collapse-button">
     <template>

--- a/ufo/static/collapseButton.js
+++ b/ufo/static/collapseButton.js
@@ -1,0 +1,20 @@
+Polymer({
+  is: "ufo-collapse-button",
+  properties: {
+    buttonText: {
+      type: String
+    },
+    collapseText: {
+      type: String
+    },
+    label: {
+      type: String
+    }
+  },
+  toggleCollapse: function(e){
+    var target = e.target;
+    var parent = target.parentElement;
+    var collapse = parent.querySelector('iron-collapse.collapse');
+    collapse.toggle();
+  }
+});

--- a/ufo/static/globalHelperFunctions.js
+++ b/ufo/static/globalHelperFunctions.js
@@ -1,7 +1,3 @@
 var submitByFormId = function(formId) {
   document.getElementById(formId).submit();
 };
-
-var toggleCollapse = function(collapseId) {
-  document.getElementById(collapseId).toggle();
-};

--- a/ufo/static/sidebar.js
+++ b/ufo/static/sidebar.js
@@ -5,6 +5,7 @@ Polymer({
     {"href": "/", "text": "Home"},
     {"href": "/user/", "text": "Users"},
     {"href": "/proxyserver/", "text": "Proxy Servers"},
+    {"href": "/chromepolicy/", "text": "Chrome Policy"},
     {"href": "/setup/", "text": "Setup"},
     {"href": "/logout/", "text": "Logout"}
     ];

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -4,6 +4,7 @@ body {
 
 paper-card {
   margin-bottom: 16px;
+  max-width: 800px;
 }
 
 form {

--- a/ufo/static/toggleInput.html
+++ b/ufo/static/toggleInput.html
@@ -1,0 +1,12 @@
+<link rel="import" href="bower_components/paper-toggle-button/paper-toggle-button.html" />
+
+<dom-module id="ufo-toggle-input">
+    <template>
+        <paper-toggle-button checked$="[[checked]]">
+          {{buttonText}}
+          <input type="hidden" name="{{inputName}}" value="[[checked]]">
+        </paper-toggle-button>
+    </template>
+
+    <script src="toggleInput.js"></script>
+</dom-module>

--- a/ufo/static/toggleInput.js
+++ b/ufo/static/toggleInput.js
@@ -1,0 +1,15 @@
+Polymer({
+  is: "ufo-toggle-input",
+  properties: {
+    inputName: {
+      type: String
+    },
+    buttonText: {
+      type: String
+    },
+    checked: {
+      type: Boolean,
+      value: false
+    }
+  }
+});

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -1,14 +1,40 @@
 {% extends "layout.html" %}
 {% block title %}Chrome Policy{% endblock %}
 {% block head %}
+  <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
 {% endblock %}
 {% block body %}
   <div id="chrome-policy-card-holder">
-    <paper-card heading="Chrome Policy JSON">
+    <paper-card heading="Chrome Managed Policy JSON">
       <div class="card-content">
-        <p>{{ policy_json }}</p>
+        <p>Chrome policy is a feature of enterprise Google devices which can
+          be used to securely add extra configuration to the uProxy frontend.
+          If you use enterprise Google devices through Google Apps for Work,
+          you can for example turn on validation for invitation links to
+          ensure you are proxying through an endpoint controlled by the
+          management console.
+        </p>
+        <p>You can adjust the values below and save to see the managed policy
+          json update. Once you are ready, you can copy and paste the managed
+          policy json below into its own file or click the download link to
+          have one generated automatically.
+        </p>
+        <p>To push your managed policy out to your devices, visit
+          <a href="https://admin.google.com/AdminHome">Google Admin Console</a>
+           and navigate to the uProxy Chrome App/Extension under Device
+          Management -> Chrome Management -> App Management. For the App and Extension, select the entry listed, then click User settings. From
+          the list of Orgs, choose which you want the policy to apply to, then
+          enable Force Installation and select Upload Configuration File.
+          Choose the json file you just created/downloaded. You may have to
+          click override to edit Force Installation or Configure's values.
+          Finally, click Save.
+        </p>
+        <paper-button onclick="toggleCollapse('collapse-policy')">Show/hide Chrome Managed Policy</paper-button>
+        <iron-collapse id="collapse-policy">
+          <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{policy_json}}</pre>
+        </iron-collapse>
       </div>
       <div class="card-actions">
         <a href="{{ url_for('chrome_policy_download') }}" download="chrome_policy.json">

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -3,8 +3,8 @@
 {% block head %}
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
-  <link rel="import" href="{{ url_for('static', filename='bower_components/paper-toggle-button/paper-toggle-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='collapseButton.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='toggleInput.html') }}" />
 {% endblock %}
 {% block body %}
   <div id="chrome-policy-card-holder">
@@ -44,15 +44,9 @@
       <div class="card-content">
         <form id="policy-config-form" method="post"
           action="{{ url_for('edit_policy_config') }}">
-          <paper-toggle-button {% if enforce_proxy_server_validity %}checked{% endif %}>
-            Enforce Proxy Server Check from Invitation Link
-            <input type="hidden" name="enforce_proxy_server_validity" value="{{ enforce_proxy_server_validity }}">
-          </paper-toggle-button>
+          <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="Enforce Proxy Server Check from Invitation Link" {% if enforce_proxy_server_validity %}checked{% endif %}></ufo-toggle-input>
           <br>
-          <paper-toggle-button {% if enforce_network_jail %}checked{% endif %}>
-            Enforce Network Jail Before Google Login
-            <input type="hidden" name="enforce_network_jail" value="{{ enforce_network_jail }}">
-          </paper-toggle-button>
+          <ufo-toggle-input input-name="enforce_network_jail" button-text="Enforce Network Jail Before Google Login" {% if enforce_network_jail %}checked{% endif %}></ufo-toggle-input>
           <br>
           <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}">
         </form>
@@ -64,16 +58,4 @@
       </div>
     </paper-card>
   </div>
-
-  <script>
-    var toggles = document.querySelectorAll('paper-toggle-button');
-
-    for (var i in toggles) {
-      toggles[i].addEventListener('change', function(event) {
-          toggleElem = event.path[0];
-          hiddenInput = toggleElem.querySelector('input');
-          hiddenInput.value = toggleElem.checked;
-      });
-    }
-  </script>
 {% endblock %}

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -71,8 +71,7 @@
   <script>
     var toggles = document.querySelectorAll('paper-toggle-button');
 
-    var i = 0;
-    for (; i < toggles.length; i++) {
+    for (var i in toggles) {
       toggles[i].addEventListener('change', function(event) {
           toggleElem = event.path[0];
           hiddenInput = toggleElem.querySelector('input');

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -38,7 +38,7 @@
         </iron-collapse>
       </div>
       <div class="card-actions">
-        <a href="{{ url_for('chrome_policy_download') }}" download="chrome_policy.json">
+        <a href="{{ url_for('download_chrome_policy') }}" download="chrome_policy.json">
           <paper-button class="anchor-button">Download</paper-button></a>
       </div>
     </paper-card>

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% block title %}Chrome Policy{% endblock %}
 {% block head %}
-  <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-toggle-button/paper-toggle-button.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='collapseButton.html') }}" />
 {% endblock %}
 {% block body %}
   <div id="chrome-policy-card-holder">
@@ -32,10 +32,7 @@
           click override to edit Force Installation or Configure's values.
           Finally, click Save.
         </p>
-        <paper-button onclick="toggleCollapse('collapse-policy')">Show/hide Chrome Managed Policy</paper-button>
-        <iron-collapse id="collapse-policy">
-          <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{policy_json}}</pre>
-        </iron-collapse>
+        <ufo-collapse-button label="Managed Policy JSON" button-text="Show/hide Chrome Managed Policy" collapse-text="{{ policy_json }}"></ufo-collapse-button>
       </div>
       <div class="card-actions">
         <a href="{{ url_for('download_chrome_policy') }}" download="chrome_policy.json">

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block title %}Chrome Policy{% endblock %}
+{% block head %}
+  <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
+{% endblock %}
+{% block body %}
+  <div id="chrome-policy-card-holder">
+    <paper-card heading="Chrome Policy JSON">
+      <div class="card-content">
+        <p>{{ policy_json }}</p>
+      </div>
+      <div class="card-actions">
+        <a href="data:{{policy_json}}" download="chrome_policy.json">
+          <paper-button class="anchor-button">Download</paper-button></a>
+      </div>
+    </paper-card>
+  </div>
+{% endblock %}

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -4,6 +4,7 @@
   <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='bower_components/paper-toggle-button/paper-toggle-button.html') }}" />
 {% endblock %}
 {% block body %}
   <div id="chrome-policy-card-holder">
@@ -41,5 +42,42 @@
           <paper-button class="anchor-button">Download</paper-button></a>
       </div>
     </paper-card>
+    <br>
+    <paper-card heading="Adjust Config Values">
+      <div class="card-content">
+        <form id="policy-config-form" method="post"
+          action="{{ url_for('edit_policy_config') }}">
+          <paper-toggle-button {% if enforce_proxy_server_validity %}checked{% endif %}>
+            Enforce Proxy Server Check from Invitation Link
+            <input type="hidden" name="enforce_proxy_server_validity" value="{{ enforce_proxy_server_validity }}">
+          </paper-toggle-button>
+          <br>
+          <paper-toggle-button {% if enforce_network_jail %}checked{% endif %}>
+            Enforce Network Jail Before Google Login
+            <input type="hidden" name="enforce_network_jail" value="{{ enforce_network_jail }}">
+          </paper-toggle-button>
+          <br>
+          <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}">
+        </form>
+      </div>
+      <div class="card-actions">
+        <paper-button onclick="submitByFormId('policy-config-form')" class="form-submit-button" type="submit">
+          Save
+        </paper-button>
+      </div>
+    </paper-card>
   </div>
+
+  <script>
+    var toggles = document.querySelectorAll('paper-toggle-button');
+
+    var i = 0;
+    for (; i < toggles.length; i++) {
+      toggles[i].addEventListener('change', function(event) {
+          toggleElem = event.path[0];
+          hiddenInput = toggleElem.querySelector('input');
+          hiddenInput.value = toggleElem.checked;
+      });
+    }
+  </script>
 {% endblock %}

--- a/ufo/templates/chrome_policy.html
+++ b/ufo/templates/chrome_policy.html
@@ -11,7 +11,7 @@
         <p>{{ policy_json }}</p>
       </div>
       <div class="card-actions">
-        <a href="data:{{policy_json}}" download="chrome_policy.json">
+        <a href="{{ url_for('chrome_policy_download') }}" download="chrome_policy.json">
           <paper-button class="anchor-button">Download</paper-button></a>
       </div>
     </paper-card>

--- a/ufo/templates/proxy_server.html
+++ b/ufo/templates/proxy_server.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% block title %}Proxy Server(s){% endblock %}
 {% block head %}
-  <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-input/paper-input.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='collapseButton.html') }}" />
 {% endblock %}
 {% block body %}
   <a href="{{ url_for('proxyserver_add') }}">
@@ -15,14 +15,8 @@
     <paper-card heading="{{ proxy_server.name }}">
       <div class="card-content">
         <p>{{ proxy_server.ip_address }}</p>
-        <paper-button onclick="toggleCollapse('collapse-{{loop.index}}')">Show/hide SSH Keys</paper-button>
-        <iron-collapse id="collapse-{{loop.index}}">
-          <h3>Public Key (for verification)</h3>
-          <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{proxy_server.public_key}}</pre>
-
-          <h3>Private Key (for authentication)</h3>
-          <pre style="width:600px; overflow: auto; word-wrap: break-word;">{{proxy_server.private_key}}</pre>
-        </iron-collapse>
+        <ufo-collapse-button label="Public Key (for verification)" button-text="Show/hide SSH Public Key" collapse-text="{{ proxy_server.public_key }}"></ufo-collapse-button></br>
+        <ufo-collapse-button label="Private Key (for verification)" button-text="Show/hide SSH Private Key" collapse-text="{{ proxy_server.private_key }}"></ufo-collapse-button>
       </div>
       <div class="card-actions">
         <a href="{{ url_for('proxyserver_edit', server_id=proxy_server.id) }}">

--- a/ufo/templates/user_details.html
+++ b/ufo/templates/user_details.html
@@ -1,9 +1,9 @@
 {% extends "layout.html" %}
 {% block title %}User Details{% endblock %}
 {% block head %}
-  <link rel="import" href="{{ url_for('static', filename='bower_components/iron-collapse/iron-collapse.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-button/paper-button.html') }}" />
   <link rel="import" href="{{ url_for('static', filename='bower_components/paper-card/paper-card.html') }}" />
+  <link rel="import" href="{{ url_for('static', filename='collapseButton.html') }}" />
 {% endblock %}
 {% block body %}
   {% set xsrf_token_value = xsrf_token() %}
@@ -18,12 +18,9 @@
             Enabled
           {% endif %}
         </b></p>
-        <paper-button onclick="toggleCollapse('collapse-pri')">Show/hide SSH Private Key</paper-button>
-        <iron-collapse id="collapse-pri"><div><textarea rows="20" cols="80">
-          {{ user.private_key }}</textarea></div></iron-collapse><br>
-        <paper-button onclick="toggleCollapse('collapse-pub')">Show/hide SSH Public Key</paper-button>
-        <iron-collapse id="collapse-pub"><div><textarea rows="20" cols="80">
-          {{ user.public_key }}</textarea></div></iron-collapse>
+        <ufo-collapse-button label="SSH Private Key" button-text="Show/hide SSH Private Key" collapse-text="{{ user.private_key }}"></ufo-collapse-button>
+        <br>
+        <ufo-collapse-button label="SSH Public Key" button-text="Show/hide SSH Public Key" collapse-text="{{ user.public_key }}"></ufo-collapse-button>
       </div>
       <div class="card-actions">
         <form id="user-delete-form" method="post" action="{{ url_for('delete_user', user_id=user.id) }}">


### PR DESCRIPTION
Currently, this reads values from the database and generates the JSON file which would be uploaded to admin console and pushed down to the uProxy app and extension. It surfaces the JSON file as a new Chrome Policy handler (at /chromepolicy/), which displays the file in a card (for copy pasting) and provides a download link users can click to have the file automatically downloaded for them.

TODO's:

<del>Add support for modifying the new config values (whether to enforce the proxy server check and whether to enforce the network jail prior to Google login) on the management server .</del>

Possibly move the current functionality (and new config value edit functionality) to be a sub-page under the setup handler rather than its own handler and link on the sidebar.

<del>Add text on the handler page to explain what chrome policy is for and where it should go, as well as a link to admin console.</del>


<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/26)

<!-- Reviewable:end -->
