### PR TITLE
Enqueue the distribution of user keys to the proxy servers.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: gunicorn ufo:app --log-file=-
 worker: python worker.py
+clock: python clock.py

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn ufo:app --log-file=-
+worker: python worker.py

--- a/app.json
+++ b/app.json
@@ -16,7 +16,8 @@
     }
   },
   "addons": [
-    "heroku-postgresql"
+    "heroku-postgresql",
+    "redistogo"
   ],
   "buildpacks": [
     {

--- a/clock.py
+++ b/clock.py
@@ -1,3 +1,8 @@
+"""This module schedules all the periodic batch processes on heroku.
+
+https://devcenter.heroku.com/articles/clock-processes-python
+"""
+
 import proxy_server
 
 from apscheduler.schedulers.blocking import BlockingScheduler
@@ -7,7 +12,7 @@ scheduler = BlockingScheduler()
 
 @scheduler.scheduled_job('interval', minutes=15)
 def distribute_user_keys_to_proxy_servers():
-  """Schedule the user key distribution to proxy servers."""
+  """Schedule the user key distribut to proxy servers."""
   print 'Start scheduling key distribution to proxy servers.'
   proxy_server.distribute_keys()
   print 'Finished scheduling key distribution to proxy servers.'

--- a/clock.py
+++ b/clock.py
@@ -9,7 +9,7 @@ import ufo
 
 SCHEDULER = BlockingScheduler()
 
-@SCHEDULER.scheduled_job('interval', minutes=15)
+@SCHEDULER.scheduled_job('interval', seconds=5)
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
   ufo.proxy_server.distribute_keys()

--- a/clock.py
+++ b/clock.py
@@ -2,11 +2,11 @@
 
 https://devcenter.heroku.com/articles/clock-processes-python
 """
-import apscheduler
+from apscheduler.schedulers.blocking import BlockingScheduler
 import ufo
 
 
-SCHEDULER = apscheduler.schedulers.blocking.BlockingScheduler()
+SCHEDULER = BlockingScheduler()
 
 @SCHEDULER.scheduled_job('interval', minutes=15)
 def distribute_user_keys_to_proxy_servers():

--- a/clock.py
+++ b/clock.py
@@ -4,7 +4,6 @@ https://devcenter.heroku.com/articles/clock-processes-python
 """
 # Use the default import to avoid module AttributeError (http://goo.gl/YM7kyZ)
 from apscheduler.schedulers.blocking import BlockingScheduler
-import logging
 import ufo
 
 

--- a/clock.py
+++ b/clock.py
@@ -13,9 +13,8 @@ SCHEDULER = BlockingScheduler()
 @SCHEDULER.scheduled_job('interval', seconds=5)
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
-  print 'running?'
-  logging.info('>>>>> logging by info')
-  logging.error('>>>>> logging by error')
+  # TODO: configure the logger to direct to stdout
+  print 'Start distributing keys to proxy server.'
   ufo.proxy_server.distribute_keys()
 
 

--- a/clock.py
+++ b/clock.py
@@ -2,19 +2,18 @@
 
 https://devcenter.heroku.com/articles/clock-processes-python
 """
-
+import apscheduler
 import proxy_server
 
-from apscheduler.schedulers.blocking import BlockingScheduler
 
+SCHEDULER = apscheduler.schedulers.blocking.BlockingScheduler()
 
-scheduler = BlockingScheduler()
-
-@scheduler.scheduled_job('interval', minutes=15)
+@SCHEDULER.scheduled_job('interval', minutes=15)
 def distribute_user_keys_to_proxy_servers():
-  """Schedule the user key distribut to proxy servers."""
+  """Schedule the user key distribution to proxy servers."""
+  # TODO: Get rid of the print by having a logger that redirects to stdout.
   print 'Start scheduling key distribution to proxy servers.'
   proxy_server.distribute_keys()
   print 'Finished scheduling key distribution to proxy servers.'
 
-scheduler.start()
+SCHEDULER.start()

--- a/clock.py
+++ b/clock.py
@@ -1,0 +1,14 @@
+import proxy_server
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+
+scheduler = BlockingScheduler()
+
+@scheduler.scheduled_job('interval', minutes=15)
+def distribute_user_keys_to_proxy_servers():
+  print 'Start scheduling key distribution to proxy servers.'
+  proxy_server.distribute_keys()
+  print 'Finished scheduling key distribution to proxy servers.'
+
+scheduler.start()

--- a/clock.py
+++ b/clock.py
@@ -12,6 +12,7 @@ SCHEDULER = BlockingScheduler()
 @SCHEDULER.scheduled_job('interval', seconds=5)
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
+  print 'running?'
   ufo.proxy_server.distribute_keys()
 
 

--- a/clock.py
+++ b/clock.py
@@ -2,6 +2,7 @@
 
 https://devcenter.heroku.com/articles/clock-processes-python
 """
+# Use the default import to avoid module AttributeError (http://goo.gl/YM7kyZ)
 from apscheduler.schedulers.blocking import BlockingScheduler
 import ufo
 

--- a/clock.py
+++ b/clock.py
@@ -9,7 +9,7 @@ import ufo
 
 SCHEDULER = BlockingScheduler()
 
-@SCHEDULER.scheduled_job('interval', seconds=15)
+@SCHEDULER.scheduled_job('interval', minutes=15)
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
   # TODO: Configure the logger to direct to stdout.

--- a/clock.py
+++ b/clock.py
@@ -10,11 +10,11 @@ import ufo
 
 SCHEDULER = BlockingScheduler()
 
-@SCHEDULER.scheduled_job('interval', seconds=5)
+@SCHEDULER.scheduled_job('interval', minutes=15)
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
-  # TODO: configure the logger to direct to stdout
-  print 'Start distributing keys to proxy server.'
+  # TODO: Configure the logger to direct to stdout.
+  print 'Start distributing user keys to proxy server.'
   ufo.proxy_server.distribute_keys()
 
 

--- a/clock.py
+++ b/clock.py
@@ -9,12 +9,13 @@ import ufo
 
 SCHEDULER = BlockingScheduler()
 
-@SCHEDULER.scheduled_job('interval', minutes=15)
+@SCHEDULER.scheduled_job('interval', seconds=15)
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
   # TODO: Configure the logger to direct to stdout.
-  print 'Start distributing user keys to proxy server.'
-  ufo.proxy_server.distribute_keys()
+  print 'Start scheduling key distribution to proxy server.'
+  key_distributor = ufo.key_distributor.KeyDistributor()
+  key_distributor.enqueue_key_distribution_jobs()
 
 
 SCHEDULER.start()

--- a/clock.py
+++ b/clock.py
@@ -12,9 +12,7 @@ SCHEDULER = BlockingScheduler()
 @SCHEDULER.scheduled_job('interval', minutes=15)
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
-  # TODO: Get rid of the print by having a logger that redirects to stdout.
-  print 'Start scheduling key distribution to proxy servers.'
   ufo.proxy_server.distribute_keys()
-  print 'Finished scheduling key distribution to proxy servers.'
+
 
 SCHEDULER.start()

--- a/clock.py
+++ b/clock.py
@@ -7,6 +7,7 @@ scheduler = BlockingScheduler()
 
 @scheduler.scheduled_job('interval', minutes=15)
 def distribute_user_keys_to_proxy_servers():
+  """Schedule the user key distribution to proxy servers."""
   print 'Start scheduling key distribution to proxy servers.'
   proxy_server.distribute_keys()
   print 'Finished scheduling key distribution to proxy servers.'

--- a/clock.py
+++ b/clock.py
@@ -4,6 +4,7 @@ https://devcenter.heroku.com/articles/clock-processes-python
 """
 # Use the default import to avoid module AttributeError (http://goo.gl/YM7kyZ)
 from apscheduler.schedulers.blocking import BlockingScheduler
+import logging
 import ufo
 
 
@@ -13,6 +14,8 @@ SCHEDULER = BlockingScheduler()
 def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
   print 'running?'
+  logging.info('>>>>> logging by info')
+  logging.error('>>>>> logging by error')
   ufo.proxy_server.distribute_keys()
 
 

--- a/clock.py
+++ b/clock.py
@@ -3,7 +3,7 @@
 https://devcenter.heroku.com/articles/clock-processes-python
 """
 import apscheduler
-import proxy_server
+import ufo
 
 
 SCHEDULER = apscheduler.schedulers.blocking.BlockingScheduler()
@@ -13,7 +13,7 @@ def distribute_user_keys_to_proxy_servers():
   """Schedule the user key distribution to proxy servers."""
   # TODO: Get rid of the print by having a logger that redirects to stdout.
   print 'Start scheduling key distribution to proxy servers.'
-  proxy_server.distribute_keys()
+  ufo.proxy_server.distribute_keys()
   print 'Finished scheduling key distribution to proxy servers.'
 
 SCHEDULER.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+APScheduler==3.0.5
 Flask==0.10.1
 Flask-SQLAlchemy==2.1
 Flask-Testing==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ paramiko==1.16.0
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
 pycrypto==2.6.1
+redis==2.10.5
+rq==0.5.6
 rsa==3.2.3
 selenium==2.49.2
 simplejson==3.8.1

--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -85,3 +85,4 @@ def setup_required(func):
 
 import xsrf
 import routes
+import key_distributor

--- a/ufo/key_distributor.py
+++ b/ufo/key_distributor.py
@@ -11,12 +11,13 @@ import worker
 class KeyDistributor(object):
   """Distributes user keys to proxy servers"""
 
-  def _make_key_string(self):
+  # VisibleForTesting
+  def make_key_string(self):
     """Generate the key string in open ssh format for pushing to proxy servers.
-  
+
     This key string includes only the public key for each user in order to grant
     the user access to each proxy server.
-  
+
     Returns:
       key_string: A string of users with associated key.
     """
@@ -31,23 +32,23 @@ class KeyDistributor(object):
         user_string = (ssh_starting_portion + space + user.public_key + space +
                        user.email + endline)
         key_string += user_string
-  
+
     return key_string
-  
+
   def _distribute_key(self, proxy_server, key_string):
     """Distributes user keys to the proxy server.
-    
+
     Args:
       proxy_server: db representation of a proxy server.
       key_string: A string of users with associated key.
     """
     client = ssh_client.SSHClient()
     client.connect(proxy_server)
-  
+
     # TODO do stuff
-  
+
     client.close()
-  
+
   def enqueue_key_distribution_jobs(self):
     """Distribute user keys to proxy servers to authenticate invite code."""
     key_string = self._make_key_string()

--- a/ufo/key_distributor.py
+++ b/ufo/key_distributor.py
@@ -25,11 +25,10 @@ class KeyDistributor(object):
     users = models.User.query.all()
     key_string = ''
     ssh_starting_portion = 'ssh-rsa'
-    space = ' '
     endline = '\n'
     for user in users:
       if not user.is_key_revoked:
-        user_string = (ssh_starting_portion + space + user.public_key + space +
+        user_string = (ssh_starting_portion + ' ' + user.public_key + space +
                        user.email + endline)
         key_string += user_string
 

--- a/ufo/key_distributor.py
+++ b/ufo/key_distributor.py
@@ -28,7 +28,7 @@ class KeyDistributor(object):
     endline = '\n'
     for user in users:
       if not user.is_key_revoked:
-        user_string = (ssh_starting_portion + ' ' + user.public_key + space +
+        user_string = (ssh_starting_portion + ' ' + user.public_key + ' ' +
                        user.email + endline)
         key_string += user_string
 

--- a/ufo/key_distributor.py
+++ b/ufo/key_distributor.py
@@ -1,8 +1,10 @@
 """The module for distributing user keys to proxy servers."""
 
-import models
 from rq import Queue
-import ssh_client
+
+import ufo
+from ufo import models
+from ufo import ssh_client
 import worker
 
 

--- a/ufo/key_distributor.py
+++ b/ufo/key_distributor.py
@@ -50,7 +50,7 @@ class KeyDistributor(object):
 
   def enqueue_key_distribution_jobs(self):
     """Distribute user keys to proxy servers to authenticate invite code."""
-    key_string = self._make_key_string()
+    key_string = self.make_key_string()
     proxy_servers = models.ProxyServer.query.all()
     queue = Queue(connection=worker.CONN)
     for proxy_server in proxy_servers:

--- a/ufo/key_distributor.py
+++ b/ufo/key_distributor.py
@@ -1,0 +1,55 @@
+"""The module for distributing user keys to proxy servers."""
+
+import models
+from rq import Queue
+import ssh_client
+import worker
+
+
+class KeyDistributor(object):
+  """Distributes user keys to proxy servers"""
+
+  def _make_key_string(self):
+    """Generate the key string in open ssh format for pushing to proxy servers.
+  
+    This key string includes only the public key for each user in order to grant
+    the user access to each proxy server.
+  
+    Returns:
+      key_string: A string of users with associated key.
+    """
+    # TODO: Improve this so that we only do this if there are relevant changes.
+    users = models.User.query.all()
+    key_string = ''
+    ssh_starting_portion = 'ssh-rsa'
+    space = ' '
+    endline = '\n'
+    for user in users:
+      if not user.is_key_revoked:
+        user_string = (ssh_starting_portion + space + user.public_key + space +
+                       user.email + endline)
+        key_string += user_string
+  
+    return key_string
+  
+  def _distribute_key(self, proxy_server, key_string):
+    """Distributes user keys to the proxy server.
+    
+    Args:
+      proxy_server: db representation of a proxy server.
+      key_string: A string of users with associated key.
+    """
+    client = ssh_client.SSHClient()
+    client.connect(proxy_server)
+  
+    # TODO do stuff
+  
+    client.close()
+  
+  def enqueue_key_distribution_jobs(self):
+    """Distribute user keys to proxy servers to authenticate invite code."""
+    key_string = self._make_key_string()
+    proxy_servers = models.ProxyServer.query.all()
+    queue = Queue(connection=worker.CONN)
+    for proxy_server in proxy_servers:
+      queue.enqueue(self._distribute_key, proxy_server, key_string)

--- a/ufo/key_distributor_test.py
+++ b/ufo/key_distributor_test.py
@@ -1,0 +1,47 @@
+"""Test key distributor module functionality."""
+
+from mock import patch
+
+import base_test
+import key_distributor
+import models
+import user_test
+
+
+class KeyDistributorTest(base_test.BaseTest):
+  """Test key distributor class functionality."""
+
+  def testUnrevokedUsersAreInKeyString(self):
+    """Test unrevoked users are in key string.."""
+    fake_users = []
+    for fake_email_and_name in user_test.FAKE_EMAILS_AND_NAMES:
+      fake_user = models.User(email=fake_email_and_name['email'],
+                              name=fake_email_and_name['name'],
+                              is_key_revoked=False)
+      fake_user.save()
+      fake_users.append(fake_user)
+    
+    key_string = key_distributor.KeyDistributor()._make_key_string()
+
+    self.assertEquals(3, key_string.count('END PUBLIC KEY'))
+    for fake_user in fake_users:
+      self.assertIn(fake_user.email, key_string)
+      self.assertIn(fake_user.public_key, key_string)
+
+  def testRevokedUsersAreNotInKeyString(self):
+    """Test revoked users are not in key string.."""
+    fake_users = []
+    for fake_email_and_name in user_test.FAKE_EMAILS_AND_NAMES:
+      fake_user = models.User(email=fake_email_and_name['email'],
+                              name=fake_email_and_name['name'],
+                              is_key_revoked=True)
+      fake_user.save()
+      fake_users.append(fake_user)
+    
+    key_string = key_distributor.KeyDistributor()._make_key_string()
+
+    self.assertFalse(key_string)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/ufo/key_distributor_test.py
+++ b/ufo/key_distributor_test.py
@@ -2,10 +2,11 @@
 
 from mock import patch
 
-import base_test
-import key_distributor
-import models
-import user_test
+import ufo
+from ufo import base_test
+from ufo import key_distributor
+from ufo import models
+from ufo import user_test
 
 
 class KeyDistributorTest(base_test.BaseTest):
@@ -20,8 +21,8 @@ class KeyDistributorTest(base_test.BaseTest):
                               is_key_revoked=False)
       fake_user.save()
       fake_users.append(fake_user)
-    
-    key_string = key_distributor.KeyDistributor()._make_key_string()
+
+    key_string = key_distributor.KeyDistributor().make_key_string()
 
     self.assertEquals(3, key_string.count('END PUBLIC KEY'))
     for fake_user in fake_users:
@@ -37,8 +38,8 @@ class KeyDistributorTest(base_test.BaseTest):
                               is_key_revoked=True)
       fake_user.save()
       fake_users.append(fake_user)
-    
-    key_string = key_distributor.KeyDistributor()._make_key_string()
+
+    key_string = key_distributor.KeyDistributor().make_key_string()
 
     self.assertFalse(key_string)
 

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -138,6 +138,7 @@ def distribute_keys():
   Returns:
     A string that tells job is enqueued.
   """
+  print '>>>>> print: inside proxy server to distribute key'
   key_string = _MakeKeyString()
   proxy_servers = models.ProxyServer.query.all()
   queue = Queue(connection=worker.CONN)

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -145,6 +145,7 @@ def distribute_keys():
   proxy_servers = models.ProxyServer.query.all()
   queue = Queue(connection=worker.CONN)
   for proxy_server in proxy_servers:
+    print '>>>>> enqueue'
     queue.enqueue(_SendKeysToServer, proxy_server, key_string)
   print 'done enqueue all jobs'
   return 'Done enqueuing all key distribution jobs!'

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -20,6 +20,7 @@ def _MakeKeyString():
   Returns:
     key_string: A string of users with associated key.
   """
+  # TODO: Improve this so that we only do this if there are relevant changes.
   users = models.User.query.all()
   key_string = ''
   ssh_starting_portion = 'ssh-rsa'

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -35,6 +35,9 @@ def _MakeKeyString():
   return key_string
 
 def _SendKeysToServer(server, keys):
+  print '>>>>>>>>print: aaaaa'
+  logging.info('>>>>>info: bbbbb')
+  logging.error('>>>>>error: ccccc')
   client = ssh_client.SSHClient()
   client.connect(server)
 

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -39,6 +39,9 @@ def _SendKeysToServer(server, keys):
   client.connect(server)
 
   # TODO do stuff
+  print '>>>>>>>> 111111'
+  logging.info('>>>>> 22222')
+  logging.info('>>>>> 33333')
 
   client.close()
 

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -35,16 +35,10 @@ def _MakeKeyString():
   return key_string
 
 def _SendKeysToServer(server, keys):
-  print '>>>>>>>>print: aaaaa'
-  logging.info('>>>>>info: bbbbb')
-  logging.error('>>>>>error: ccccc')
   client = ssh_client.SSHClient()
   client.connect(server)
 
   # TODO do stuff
-  print '>>>>>>>>print: 111111'
-  logging.info('>>>>>info: 22222')
-  logging.error('>>>>>error: 33333')
 
   client.close()
 
@@ -141,14 +135,9 @@ def distribute_keys():
   Returns:
     A string that tells job is enqueued.
   """
-  print '>>>>> print: inside proxy server to distribute key'
-  logging.info('>>>>> info: inside proxy server to distribute key')
-  logging.error('>>>>> error: inside proxy server to distribute key')
   key_string = _MakeKeyString()
   proxy_servers = models.ProxyServer.query.all()
   queue = Queue(connection=worker.CONN)
   for proxy_server in proxy_servers:
-    print '>>>>> enqueue'
     queue.enqueue(_SendKeysToServer, proxy_server, key_string)
-  print 'done enqueue all jobs'
   return 'Done enqueuing all key distribution jobs!'

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -3,9 +3,11 @@
 from . import app, db, setup_required
 
 import flask
-import models
-import ssh_client
 import StringIO
+
+import ufo
+from ufo import models
+from ufo import ssh_client
 
 
 def _GetViewDataFromProxyServer(server):

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -39,9 +39,9 @@ def _SendKeysToServer(server, keys):
   client.connect(server)
 
   # TODO do stuff
-  print '>>>>>>>> 111111'
-  logging.info('>>>>> 22222')
-  logging.info('>>>>> 33333')
+  print '>>>>>>>>print: 111111'
+  logging.info('>>>>>info: 22222')
+  logging.error('>>>>>error: 33333')
 
   client.close()
 
@@ -139,9 +139,12 @@ def distribute_keys():
     A string that tells job is enqueued.
   """
   print '>>>>> print: inside proxy server to distribute key'
+  logging.info('>>>>> info: inside proxy server to distribute key')
+  logging.error('>>>>> error: inside proxy server to distribute key')
   key_string = _MakeKeyString()
   proxy_servers = models.ProxyServer.query.all()
   queue = Queue(connection=worker.CONN)
   for proxy_server in proxy_servers:
     queue.enqueue(_SendKeysToServer, proxy_server, key_string)
+  print 'done enqueue all jobs'
   return 'Done enqueuing all key distribution jobs!'

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -8,7 +8,7 @@ import models
 from rq import Queue
 import ssh_client
 import StringIO
-from worker import conn
+import worker
 
 
 def _MakeKeyString():
@@ -137,7 +137,7 @@ def distribute_keys():
   """
   key_string = _MakeKeyString()
   proxy_servers = models.ProxyServer.query.all()
-  queue = Queue(connection=conn)
+  queue = Queue(connection=worker.CONN)
   for proxy_server in proxy_servers:
     queue.enqueue(_SendKeysToServer, proxy_server, key_string)
   return 'Done enqueuing all key distribution jobs!'

--- a/ufo/proxy_server.py
+++ b/ufo/proxy_server.py
@@ -128,9 +128,13 @@ def proxyserver_delete(server_id):
 
   return flask.redirect(flask.url_for('proxyserver_list'))
 
-@setup_required
+# TODO: Move this to a different module as it not a handled request.
 def distribute_keys():
-  """Distribute user keys to proxy servers to authenticate invite code."""
+  """Distribute user keys to proxy servers to authenticate invite code.
+  
+  Returns:
+    A string that tells job is enqueued.
+  """
   key_string = _MakeKeyString()
   proxy_servers = models.ProxyServer.query.all()
   queue = Queue(connection=conn)

--- a/ufo/routes.py
+++ b/ufo/routes.py
@@ -8,6 +8,7 @@ def landing():
   return flask.render_template('landing.html',
                                site_verification_content=config.dv_content)
 
-import setup # handlers for /setup
-import user # handlers for /user
-import proxy_server # handlers for /proxy_server
+import setup  # handlers for /setup
+import user  # handlers for /user
+import proxy_server  # handlers for /proxy_server
+import key_distributor  # distributes user keys to proxy servers

--- a/ufo/routes.py
+++ b/ufo/routes.py
@@ -11,4 +11,3 @@ def landing():
 import setup  # handlers for /setup
 import user  # handlers for /user
 import proxy_server  # handlers for /proxy_server
-import key_distributor  # distributes user keys to proxy servers

--- a/ufo/user_test.py
+++ b/ufo/user_test.py
@@ -20,6 +20,7 @@ import models
 import oauth
 import user
 
+
 FAKE_EMAILS_AND_NAMES = [
   {'email': 'foo@aol.com', 'name': 'joe'},
   {'email': 'bar@yahoo.com', 'name': 'bob'},
@@ -43,6 +44,8 @@ FAKE_MODEL_USER = MagicMock(email=FAKE_EMAILS_AND_NAMES[0]['email'],
                             private_key='private key foo',
                             public_key='public key bar',
                             is_key_revoked=False)
+
+
 class UserTest(base_test.BaseTest):
   """Test user class functionality."""
 

--- a/worker.py
+++ b/worker.py
@@ -20,14 +20,14 @@ from rq import Queue
 from rq import Worker
 
 
-listen = ['high', 'default', 'low']
+LISTEN = ['high', 'default', 'low']
 
-redis_url = os.getenv('REDISTOGO_URL', 'redis://localhost:6379')
+REDIS_URL = os.getenv('REDISTOGO_URL', 'redis://localhost:6379')
 
-conn = redis.from_url(redis_url)
+CONN = redis.from_url(REDIS_URL)
 
 
 if __name__ == '__main__':
-  with Connection(conn):
-    worker = Worker(map(Queue, listen))
+  with Connection(CONN):
+    worker = Worker(map(Queue, LISTEN))
     worker.work()

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,33 @@
+"""The module for creating workers to process background jobs.
+
+Based on the heroku guide:
+https://devcenter.heroku.com/articles/python-rq
+
+See "Queuing jobs" section on how to enqueue jobs.
+https://devcenter.heroku.com/articles/python-rq#queuing-jobs
+
+The worker does not start by default after deployment.  It will be necessary
+to start manually such as:
+heroku ps:scale worker=N
+where N is the number of workers that you want.
+"""
+
+import os
+
+import redis
+from rq import Connection
+from rq import Queue
+from rq import Worker
+
+
+listen = ['high', 'default', 'low']
+
+redis_url = os.getenv('REDISTOGO_URL', 'redis://localhost:6379')
+
+conn = redis.from_url(redis_url)
+
+
+if __name__ == '__main__':
+  with Connection(conn):
+    worker = Worker(map(Queue, listen))
+    worker.work()


### PR DESCRIPTION
- this PR covers the ability to enqueue background jobs
- enqueue the key distribution as a background job; I think we want to enqueue each server separately as a job so that it's easier for the workers to pickup; but if not please let me know of a better way
- add clock process to schedule job, i.e. what's the trigger to enqueue jobs 
- I have manually tested this for now on my heroku instance, but i think we can write a functional test later on
- heroku will not start workers automatically; does anyone know a better process to start the worker?
  https://devcenter.heroku.com/articles/procfile#scaling-a-process-type
  look for "other process types don’t start by default"

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/27)

<!-- Reviewable:end -->
