### PR TITLE
Fix Vulcanization on Heroku by Adding to the Postdeploy Process in App.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   "logo": "https://uproxy.org/images/uproxy_logo.svg",
   "success_url": "/setup",
   "scripts": {
-    "postdeploy": "python setup_database.py"
+    "postdeploy": "python setup_database.py && ./vulcanize.sh travis"
   },
   "env": {
     "SECRET_KEY": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "ufo-management-server",
   "dependencies": {
-    "bower": "^1.7.1"
+    "bower": "^1.7.1",
+    "vulcanize": "^1.14.5"
   },
   "scripts": {
     "postinstall": "bower install"


### PR DESCRIPTION
The vulcanization script won't create the necessary file when run after deploying to heroku so I've made it part of the deployment in app.json. This also adds vulcanization to the dependencies in package.json so that it is already available without having to be installed manually.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/42)

<!-- Reviewable:end -->
