### PR TITLE
Fixing Vulcanize on Heroku (Again)

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   "logo": "https://uproxy.org/images/uproxy_logo.svg",
   "success_url": "/setup",
   "scripts": {
-    "postdeploy": "python setup_database.py && ./vulcanize.sh travis"
+    "postdeploy": "python setup_database.py"
   },
   "env": {
     "SECRET_KEY": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "vulcanize": "^1.14.5"
   },
   "scripts": {
-    "postinstall": "bower install"
+    "postinstall": "bower install && ./vulcanize.sh travis"
   }
 }


### PR DESCRIPTION
Moving from postdeploy event step in app.json to postinstall event step in package.json which seemed to work in another branch.

My previous PR didn't actually address the issue, but my changes to allow the vulcanized.html file in gitignore (and subsequent changes to restore gitignore) masked the issue. Now it is generating the correct html file as part of the build without us checking in vulcanized.html to source control. If there are any issues using this, please let me know ASAP, and I'll investigate.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/43)

<!-- Reviewable:end -->
