### PR TITLE
Clean-up Importings in Backend

### DIFF
--- a/ufo/base_test.py
+++ b/ufo/base_test.py
@@ -2,8 +2,7 @@
 
 from flask.ext.testing import TestCase
 
-from ufo import app
-from ufo import db
+import ufo
 from ufo.database import models
 
 
@@ -11,12 +10,12 @@ class BaseTest(TestCase):
   """Base test with comment setup and teardown."""
 
   def create_app(self):
-    app.config.from_object('config.TestConfiguration')
-    return app
+    ufo.app.config.from_object('config.TestConfiguration')
+    return ufo.app
 
   def setUp(self):
     """Setup test app on which to call handlers and db to query."""
-    db.create_all()
+    ufo.db.create_all()
 
   def setup_config(self):
     """Setup the config that is needed for @setup_required decorator."""
@@ -27,5 +26,5 @@ class BaseTest(TestCase):
     self.config.save()
 
   def tearDown(self):
-    db.session.remove()
-    db.drop_all()
+    ufo.db.session.remove()
+    ufo.db.drop_all()

--- a/ufo/database/models.py
+++ b/ufo/database/models.py
@@ -4,7 +4,7 @@ from Crypto.PublicKey import RSA
 from paramiko import hostkeys
 from paramiko import pkey
 
-from ufo import db
+import ufo
 from ufo.services import ssh_client
 
 LONG_STRING_LENGTH = 1024
@@ -12,7 +12,7 @@ REVOKED_TEXT = 'Access Disabled'
 NOT_REVOKED_TEXT = 'Access Enabled'
 
 
-class Model(db.Model):
+class Model(ufo.db.Model):
   """Helpful functions for the database models
 
   Most method implementations are taken from
@@ -25,14 +25,14 @@ class Model(db.Model):
     return commit and self.save() or self
 
   def save(self, commit=True):
-    db.session.add(self)
+    ufo.db.session.add(self)
     if commit:
-      db.session.commit()
+      ufo.db.session.commit()
     return self
 
   def delete(self, commit=True):
-    db.session.delete(self)
-    return commit and db.session.commit()
+    ufo.db.session.delete(self)
+    return commit and ufo.db.session.commit()
 
   def to_dict(self):
     return {}
@@ -52,15 +52,16 @@ class Config(Model):
   """
   __tablename__ = 'config'
 
-  id = db.Column(db.Integer, primary_key=True)
+  id = ufo.db.Column(ufo.db.Integer, primary_key=True)
 
-  isConfigured = db.Column(db.Boolean(), default=False)
+  isConfigured = ufo.db.Column(ufo.db.Boolean(), default=False)
 
-  credentials = db.Column(db.Text())
-  domain = db.Column(db.String(LONG_STRING_LENGTH))
-  dv_content = db.Column(db.String(LONG_STRING_LENGTH))
-  proxy_server_validity = db.Column(db.Boolean(), default=False)
-  network_jail_until_google_auth = db.Column(db.Boolean(), default=False)
+  credentials = ufo.db.Column(ufo.db.Text())
+  domain = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  dv_content = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  proxy_server_validity = ufo.db.Column(ufo.db.Boolean(), default=False)
+  network_jail_until_google_auth = ufo.db.Column(ufo.db.Boolean(),
+                                                 default=False)
 
 
 class User(Model):
@@ -68,13 +69,13 @@ class User(Model):
   """
   __tablename__ = "user"
 
-  id = db.Column(db.Integer, primary_key=True)
+  id = ufo.db.Column(ufo.db.Integer, primary_key=True)
 
-  email = db.Column(db.String(LONG_STRING_LENGTH))
-  name = db.Column(db.String(LONG_STRING_LENGTH))
-  private_key = db.Column(db.LargeBinary())
-  public_key = db.Column(db.LargeBinary())
-  is_key_revoked = db.Column(db.Boolean(), default=False)
+  email = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  name = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  private_key = ufo.db.Column(ufo.db.LargeBinary())
+  public_key = ufo.db.Column(ufo.db.LargeBinary())
+  is_key_revoked = ufo.db.Column(ufo.db.Boolean(), default=False)
 
   def __init__(self, **kwargs):
     super(User, self).__init__(**kwargs)
@@ -118,14 +119,14 @@ class ProxyServer(Model):
   """
   __tablename__ = "proxyserver"
 
-  id = db.Column(db.Integer, primary_key=True)
+  id = ufo.db.Column(ufo.db.Integer, primary_key=True)
 
-  ip_address = db.Column(db.String(LONG_STRING_LENGTH))
-  name = db.Column(db.String(LONG_STRING_LENGTH))
-  ssh_private_key = db.Column(db.LargeBinary())
-  ssh_private_key_type = db.Column(db.String(LONG_STRING_LENGTH))
-  host_public_key = db.Column(db.LargeBinary())
-  host_public_key_type = db.Column(db.String(LONG_STRING_LENGTH))
+  ip_address = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  name = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  ssh_private_key = ufo.db.Column(ufo.db.LargeBinary())
+  ssh_private_key_type = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  host_public_key = ufo.db.Column(ufo.db.LargeBinary())
+  host_public_key_type = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
 
   def read_private_key_from_file_contents(self, contents):
     pkey_instance = pkey.PKey()

--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -1,7 +1,8 @@
 """The module for generating and outputing chrome policy."""
 
-import flask
 import json
+
+import flask
 
 import ufo
 from ufo.database import models

--- a/ufo/handlers/chrome_policy_test.py
+++ b/ufo/handlers/chrome_policy_test.py
@@ -1,9 +1,10 @@
 """Test chrome policy module functionality."""
 
-import flask
 import json
-import mock
 import unittest
+
+import flask
+import mock
 
 import ufo
 from ufo import base_test

--- a/ufo/handlers/proxy_server.py
+++ b/ufo/handlers/proxy_server.py
@@ -4,9 +4,6 @@ import json
 import flask
 
 import ufo
-from ufo import app
-from ufo import db
-from ufo import setup_required
 from ufo.database import models
 from ufo.services import ssh_client
 
@@ -29,15 +26,15 @@ def get_proxy_resources_dict():
     'isProxyServer': True,
   }
 
-@app.route('/proxyserver/')
-@setup_required
+@ufo.app.route('/proxyserver/')
+@ufo.setup_required
 def proxyserver_list():
   proxy_server_dict = {'items': models.ProxyServer.get_items_as_list_of_dict()}
   proxy_servers_json = json.dumps((proxy_server_dict))
   return flask.Response(proxy_servers_json, mimetype='application/json')
 
-@app.route('/proxyserver/add', methods=['GET', 'POST'])
-@setup_required
+@ufo.app.route('/proxyserver/add', methods=['GET', 'POST'])
+@ufo.setup_required
 def proxyserver_add():
   """Get the form for adding new proxy servers."""
   if flask.request.method == 'GET':
@@ -64,8 +61,8 @@ def proxyserver_add():
 
   return flask.redirect(flask.url_for('proxyserver_list'))
 
-@app.route('/proxyserver/<server_id>/edit', methods=['GET', 'POST'])
-@setup_required
+@ufo.app.route('/proxyserver/<server_id>/edit', methods=['GET', 'POST'])
+@ufo.setup_required
 def proxyserver_edit(server_id):
   server = models.ProxyServer.query.get_or_404(server_id)
 
@@ -83,8 +80,8 @@ def proxyserver_edit(server_id):
 
   return flask.redirect(flask.url_for('proxyserver_list'))
 
-@app.route('/proxyserver/<server_id>/delete')
-@setup_required
+@ufo.app.route('/proxyserver/<server_id>/delete')
+@ufo.setup_required
 def proxyserver_delete(server_id):
   """Handler for deleting an existing proxy server."""
   #TODO should at least be post

--- a/ufo/handlers/proxy_server_test.py
+++ b/ufo/handlers/proxy_server_test.py
@@ -7,7 +7,7 @@ from mock import MagicMock
 from mock import patch
 
 from ufo import base_test
-from ufo import models
+from ufo.database import models
 from ufo.handlers import proxy_server
 
 

--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -2,20 +2,19 @@ import json
 
 import flask
 
-from ufo import app
+import ufo
 from ufo.handlers import chrome_policy
-from ufo import get_user_config
 from ufo.handlers import proxy_server
 from ufo.handlers import user
 
 
-@app.route('/')
+@ufo.app.route('/')
 def landing():
-  config = get_user_config()
+  config = ufo.get_user_config()
   return flask.render_template('landing.html',
                                site_verification_content=config.dv_content)
 
-@app.route('/new')
+@ufo.app.route('/new')
 def new_landing():
   user_resources_dict = user.get_user_resources_dict()
   proxy_resources_dict = proxy_server.get_proxy_resources_dict()

--- a/ufo/handlers/setup.py
+++ b/ufo/handlers/setup.py
@@ -5,8 +5,7 @@ from googleapiclient import discovery
 import httplib2
 import oauth2client
 
-from ufo import app
-from ufo import get_user_config
+import ufo
 from ufo.handlers import chrome_policy
 from ufo.services import oauth
 
@@ -15,10 +14,10 @@ DOMAIN_INVALID_TEXT = 'Credentials for another domain.'
 NON_ADMIN_TEXT = 'Credentials do not have admin access.'
 
 
-@app.route('/setup/', methods=['GET', 'POST'])
+@ufo.app.route('/setup/', methods=['GET', 'POST'])
 def setup():
   """Handle showing the user the setup page and processing the response"""
-  config = get_user_config()
+  config = ufo.get_user_config()
   flow = oauth.getOauthFlow()
   oauth_url = flow.step1_get_authorize_url()
 

--- a/ufo/handlers/setup_test.py
+++ b/ufo/handlers/setup_test.py
@@ -1,14 +1,13 @@
 """Test setup module functionality."""
-from mock import MagicMock
-from mock import patch
+
+import unittest
 
 import flask
 from googleapiclient import discovery
-import unittest
+from mock import MagicMock
+from mock import patch
 
-from ufo import app
 from ufo import base_test
-from ufo import db
 from ufo.database import models
 from ufo.handlers import setup
 from ufo.services import oauth

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -1,15 +1,13 @@
 """User module which provides handlers to access and edit users."""
 import ast
 import base64
-import flask
 import json
 import random
 
+import flask
 from googleapiclient import errors
 
-from ufo import app
-from ufo import db
-from ufo import setup_required
+import ufo
 from ufo.database import models
 from ufo.services import google_directory_service
 from ufo.services import oauth
@@ -150,8 +148,8 @@ def get_user_resources_dict():
     'isUser': True,
   }
 
-@app.route('/user/')
-@setup_required
+@ufo.app.route('/user/')
+@ufo.setup_required
 def user_list():
   """Retrieves a list of the users currently in the db.
 
@@ -161,8 +159,8 @@ def user_list():
   users_json = json.dumps(({'items': models.User.get_items_as_list_of_dict()}))
   return flask.Response(users_json, mimetype='application/json')
 
-@app.route('/user/add', methods=['GET', 'POST'])
-@setup_required
+@ufo.app.route('/user/add', methods=['GET', 'POST'])
+@ufo.setup_required
 def add_user():
   """Renders the user add template on get and stores new user(s) on post.
 
@@ -190,12 +188,12 @@ def add_user():
     db_user.save(commit=False)
 
   if len(users_list) > 0:
-    db.session.commit()
+    ufo.db.session.commit()
 
   return flask.redirect(flask.url_for('user_list'))
 
-@app.route('/user/<user_id>/details')
-@setup_required
+@ufo.app.route('/user/<user_id>/details')
+@ufo.setup_required
 def user_details(user_id):
   """Renders the user details template for the given user_id if found.
 
@@ -218,8 +216,8 @@ def user_details(user_id):
     return flask.render_template('user_details.html', user=user,
                                  invite_url=invite_url)
 
-@app.route('/user/<user_id>/delete', methods=['POST'])
-@setup_required
+@ufo.app.route('/user/<user_id>/delete', methods=['POST'])
+@ufo.setup_required
 def delete_user(user_id):
   """Deletes the user corresponding to the passed in user_id from the db.
 
@@ -238,8 +236,8 @@ def delete_user(user_id):
 
   return flask.redirect(flask.url_for('user_list'))
 
-@app.route('/user/<user_id>/getNewKeyPair', methods=['POST'])
-@setup_required
+@ufo.app.route('/user/<user_id>/getNewKeyPair', methods=['POST'])
+@ufo.setup_required
 def user_get_new_key_pair(user_id):
   """Rotates the key pair (public and private keys) for the given user.
 
@@ -258,8 +256,8 @@ def user_get_new_key_pair(user_id):
 
   return flask.redirect(flask.url_for('user_details', user_id=user_id))
 
-@app.route('/user/<user_id>/toggleRevoked', methods=['POST'])
-@setup_required
+@ufo.app.route('/user/<user_id>/toggleRevoked', methods=['POST'])
+@ufo.setup_required
 def user_toggle_revoked(user_id):
   """Toggles whether the given user's access is revoked or not.
 

--- a/ufo/handlers/user_test.py
+++ b/ufo/handlers/user_test.py
@@ -1,18 +1,16 @@
 """Test user module functionality."""
-from mock import MagicMock
-from mock import patch
-
 import base64
-import flask
-from googleapiclient import errors
 import json
 import unittest
+
+import flask
+from googleapiclient import errors
+from mock import MagicMock
+from mock import patch
 from werkzeug.datastructures import MultiDict
 from werkzeug.datastructures import ImmutableMultiDict
 
-from ufo import app
 from ufo import base_test
-from ufo import db
 from ufo.database import models
 from ufo.handlers import user
 # I practically have to shorten this name so every single line doesn't go

--- a/ufo/services/error_handler_test.py
+++ b/ufo/services/error_handler_test.py
@@ -1,7 +1,6 @@
+import flask
 from mock import MagicMock
 from mock import patch
-
-import flask
 from werkzeug import exceptions
 
 from ufo import base_test

--- a/ufo/services/key_distributor_test.py
+++ b/ufo/services/key_distributor_test.py
@@ -2,7 +2,6 @@
 
 from mock import patch
 
-import ufo
 from ufo import base_test
 from ufo.database import models
 from ufo.handlers import user_test

--- a/ufo/services/oauth.py
+++ b/ufo/services/oauth.py
@@ -4,8 +4,7 @@ import flask
 from oauth2client import client
 from oauth2client import util
 
-from ufo import app
-from ufo import get_user_config
+import ufo
 
 
 OAUTH_SCOPES = [
@@ -16,12 +15,12 @@ OAUTH_SCOPES = [
 ]
 
 def getOauthFlow():
-  config = get_user_config()
+  config = ufo.get_user_config()
   # TODO give user an option to input their own and go through a different flow
   # to handle it
   return client.OAuth2WebServerFlow(
-      client_id=app.config.get('SHARED_OAUTH_CLIENT_ID'),
-      client_secret=app.config.get('SHARED_OAUTH_CLIENT_SECRET'),
+      client_id=ufo.app.config.get('SHARED_OAUTH_CLIENT_ID'),
+      client_secret=ufo.app.config.get('SHARED_OAUTH_CLIENT_SECRET'),
       scope=util.scopes_to_string(OAUTH_SCOPES),
       redirect_uri='urn:ietf:wg:oauth:2.0:oob',
   )
@@ -29,7 +28,7 @@ def getOauthFlow():
 def getSavedCredentials():
   credentials = getattr(flask.g, '_credentials', None)
   if not credentials:
-    config = get_user_config()
+    config = ufo.get_user_config()
     if not config.credentials:
       return None
 

--- a/ufo/services/xsrf.py
+++ b/ufo/services/xsrf.py
@@ -3,16 +3,16 @@ import os
 
 import flask
 
-from ufo import app
+import ufo
 
 
-@app.before_request
+@ufo.app.before_request
 def xsrf_protect():
   """Verifies that an xsrf token is included for all non-get requests
 
   Slight modification of http://flask.pocoo.org/snippets/3/
   """
-  if app.config['TESTING']:
+  if ufo.app.config['TESTING']:
     return
   if flask.request.method != 'GET':
     token = flask.session.pop('_xsrf_token', None)
@@ -24,4 +24,4 @@ def generate_xsrf_token():
     flask.session['_xsrf_token'] = binascii.b2a_hex(os.urandom(16))
   return flask.session['_xsrf_token']
 
-app.jinja_env.globals['xsrf_token'] = generate_xsrf_token
+ufo.app.jinja_env.globals['xsrf_token'] = generate_xsrf_token


### PR DESCRIPTION
As requested in the previous PR:
- Fix the imports for app, db, setup_required, get_user_config so that they are imported via import ufo and referenced as ufo.app, ufo.db, ufo.setup_required, ufo.get_user_config, etc, since they are each fields/functions in a module rather than a class.
- Fix the import orders wherever I caught them.  Basically, the import order should be:
  (1) standard library
  (2) third-party modules
  (3) application-specific modules
- Worth mentioning again that it's sweet to have the tests in place, and makes this kind of change a breeze!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/49)

<!-- Reviewable:end -->
