### PR TITLE
New UI for the oauth configuration.

### DIFF
--- a/ufo/database/models.py
+++ b/ufo/database/models.py
@@ -65,7 +65,7 @@ class Config(Model):
 
   def to_dict(self):
     """Get the config as a dict.
-    
+
       Returns: A dictionary of the config.
     """
     return {

--- a/ufo/database/models.py
+++ b/ufo/database/models.py
@@ -63,6 +63,20 @@ class Config(Model):
   network_jail_until_google_auth = ufo.db.Column(ufo.db.Boolean(),
                                                  default=False)
 
+  def to_dict(self):
+    """Get the config as a dict.
+    
+      Returns: A dictionary of the config.
+    """
+    return {
+      'is_configured': self.isConfigured,
+      'credentials': self.credentials,
+      'domain': self.domain,
+      'dv_content': self.dv_content,
+      'proxy_server_validity': self.proxy_server_validity,
+      'network_jail_until_google_auth': self.network_jail_until_google_auth,
+    }
+
 
 class User(Model):
   """Class for information about the users of the proxy servers
@@ -104,14 +118,13 @@ class User(Model):
     self.public_key = key_pair['public_key']
 
   def to_dict(self):
-    to_return = {
+    return {
       'email': self.email,
       'name': self.name,
       'private_key': self.private_key,
       'public_key': self.public_key,
       'access': REVOKED_TEXT if self.is_key_revoked else NOT_REVOKED_TEXT,
     }
-    return to_return
 
 
 class ProxyServer(Model):

--- a/ufo/database/models_test.py
+++ b/ufo/database/models_test.py
@@ -79,5 +79,30 @@ class ProxyServerTest(base_test.BaseTest):
     self.assertIn('private_key', server_dict)
 
 
+class ConfigTest(base_test.BaseTest):
+  """Test for config model class functionality."""
+
+  def testConfigToDict(self):
+    """Whether the necessary fields match in a dictionary representation."""
+
+    config = models.Config()
+    config.isConfigured = True
+    config.credentials = 'fake credential'
+    config.domain = 'fake domain'
+    config.dv_content = 'fake dv content'
+    config.proxy_server_validity = True
+    config.network_jail_until_google_auth = True
+    config_dict = config.to_dict()
+
+    self.assertEqual(config_dict['is_configured'], config.isConfigured)
+    self.assertEqual(config_dict['credentials'], config.credentials)
+    self.assertEqual(config_dict['domain'], config.domain)
+    self.assertEqual(config_dict['dv_content'], config.dv_content)
+    self.assertEqual(config_dict['proxy_server_validity'],
+                     config.proxy_server_validity)
+    self.assertEqual(config_dict['network_jail_until_google_auth'],
+                     config.network_jail_until_google_auth)
+    
+
 if __name__ == '__main__':
   unittest.main()

--- a/ufo/handlers/setup.py
+++ b/ufo/handlers/setup.py
@@ -15,28 +15,45 @@ DOMAIN_INVALID_TEXT = 'Credentials for another domain.'
 NON_ADMIN_TEXT = 'Credentials do not have admin access.'
 
 
+def _get_oauth_configration_resources_dict(config, oauth_url):
+  """Get the resources for the oauth configuration component.
+
+    Args:
+      config: A database object representing the config data.
+      oauth_url: A string of the URL to get the oauth code.
+
+    Returns:
+      A dict of the resources for the oauth configuration component.
+  """
+  return {
+    'config': config.to_dict(),
+    'oauth_url': oauth_url,
+    'setup_url': flask.url_for('setup'),
+    'showAddButton': False,
+    'titleText': 'Oauth Configuration',
+  }
+
+
 @ufo.app.route('/setup/', methods=['GET', 'POST'])
 def setup():
   """Handle showing the user the setup page and processing the response"""
+
   config = ufo.get_user_config()
   flow = oauth.getOauthFlow()
   oauth_url = flow.step1_get_authorize_url()
 
   if flask.request.method == 'GET':
-    policy_resources_dict = chrome_policy.get_policy_resources_dict()
-    setup_resources_dict = {
-      'titleText': 'OAuth Configuration',
-      'isOAuth': True,
-      'showAddButton': False,
-    }
     user_resources_dict = user.get_user_resources_dict()
     user_resources_dict['showAddButton'] = False
+    oauth_resources_dict = _get_oauth_configration_resources_dict(config,
+                                                                  oauth_url)
+    policy_resources_dict = chrome_policy.get_policy_resources_dict()
+    
     return flask.render_template(
         'setup.html',
-        config=config,
         oauth_url=oauth_url,
         policy_resources=json.dumps(policy_resources_dict),
-        setup_resources=json.dumps(setup_resources_dict),
+        oauth_resources=json.dumps(oauth_resources_dict),
         user_resources=json.dumps(user_resources_dict))
 
   if flask.request.form.get('oauth_code', None):

--- a/ufo/handlers/setup.py
+++ b/ufo/handlers/setup.py
@@ -48,7 +48,7 @@ def setup():
     oauth_resources_dict = _get_oauth_configration_resources_dict(config,
                                                                   oauth_url)
     policy_resources_dict = chrome_policy.get_policy_resources_dict()
-    
+
     return flask.render_template(
         'setup.html',
         oauth_url=oauth_url,

--- a/ufo/handlers/setup_test.py
+++ b/ufo/handlers/setup_test.py
@@ -38,8 +38,10 @@ class SetupTest(base_test.BaseTest):
 
     args, kwargs = mock_render_template.call_args
     self.assertEquals('setup.html', args[0])
-    self.assertIsNotNone(kwargs['config'])
+    self.assertIsNotNone(kwargs['oauth_resources'])
+    self.assertIsNotNone(kwargs['policy_resources'])
     self.assertIsNotNone(kwargs['oauth_url'])
+    self.assertIsNotNone(kwargs['user_resources'])
 
   @patch.object(discovery, 'build')
   @patch.object(oauth, 'getOauthFlow')

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -67,7 +67,7 @@
     <form id="oauth-configuration-form" method="post" action="{{resources.setup_url}}">
       <paper-input label="Domain" name="domain"></paper-input>
       <paper-input label="OAuth Code" name="oauth_code"></paper-input>
-      <input type="hidden" name="_xsrf_token" value="{{xsrf_token()}}" />
+      <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
       <paper-button onclick="submitByFormId('oauth-configuration-form')" class="form-submit-button anchor-button" type="submit">
         Submit
       </paper-button>
@@ -81,6 +81,9 @@
         resources: {
           type: Object,
         },
+      },
+      getXsrfToken: function() {
+        return document.getElementById('globalXsrf').value;
       },
       isDomainConfigured: function(config) {
         return config.domain && config.credentials; 

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -3,7 +3,7 @@
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />>
 
-<dom-module id="oauth-configuration-form">
+<dom-module id="oauth-configuration">
   <template>
     <!-- TODO make a clear way to say you do not want to use Google apps -->
     <template is="dom-if" if="{{!resources.config.is_configured}}">
@@ -76,7 +76,7 @@
 
   <script>
     Polymer({
-      is: 'oauth-configuration-form',
+      is: 'oauth-configuration',
       properties: {
         resources: {
           type: Object,

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -5,7 +5,8 @@
 
 <dom-module id="oauth-configuration">
   <template>
-    <!-- TODO make a clear way to say you do not want to use Google apps -->
+    <!-- TODO: Make a clear way to say you do not want to use Google apps. -->
+    <!-- TODO: Extract these strings so they can be i18n. -->
     <template is="dom-if" if="{{!resources.config.is_configured}}">
       <p>
         Hey there!  Welcome to the uProxy for Organizations management server!
@@ -22,7 +23,7 @@
         If you do not plan on using a Google apps domain with this product, you
         can just go straight to adding users.
       </p>
-    </template>    
+    </template>
 
     <template is="dom-if" if="{{resources.config.is_configured}}">
       <p>

--- a/ufo/static/oauthConfigurationForm.html
+++ b/ufo/static/oauthConfigurationForm.html
@@ -1,0 +1,90 @@
+<link rel="import" href="bower_components/paper-button/paper-button.html" />
+<link rel="import" href="bower_components/paper-input/paper-input.html" />
+<link rel="import" href="bower_components/paper-item/paper-item.html" />
+<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />>
+
+<dom-module id="oauth-configuration-form">
+  <template>
+    <!-- TODO make a clear way to say you do not want to use Google apps -->
+    <template is="dom-if" if="{{!resources.config.is_configured}}">
+      <p>
+        Hey there!  Welcome to the uProxy for Organizations management server!
+        To start, we want to get a bit of information from you to get everything
+        set up.
+      </p>
+
+      <p>
+        First of all, if you are planning on using this application with a Google
+        apps domain, we're going to need to get permission from you to access
+        that.  This will be used to keep the list of users in your domain in sync
+        with who is allowed to access the uProxy servers.  The credentials you
+        authorize will be shared by any administrators who log into this server.
+        If you do not plan on using a Google apps domain with this product, you
+        can just go straight to adding users.
+      </p>
+    </template>    
+
+    <template is="dom-if" if="{{resources.config.is_configured}}">
+      <p>
+        You have already successfully configured this deployment!  If you want to
+        change the settings, you may do so below.  Please note: submitting the
+        form even without filling in any parameters will cause the previous saved
+        configuration to be lost.
+      </p>
+
+      <template is="dom-if" if="{{isDomainConfigured(resources.config)}}">
+        <p>
+          This site is set up to work with the
+          <strong>{{resources.config.domain}}</strong> domain.  If that is not correct,
+          please update the configuration.
+        </p>
+      </template>
+
+      <template is="dom-if" if="{{!isDomainConfigured(resources.config)}}">
+        <p>
+          This site is not set up to use any Google apps domain name, all users
+          will need to be manually input.
+        </p>
+      </template>
+
+    </template>
+
+    <p>
+      Please keep in mind that this is a much simpler version than what you
+      would actually expect to see in a finished version of the site.
+      Noteably, this page should include something about authenticating
+      yourself in the future (and actually include a way to skip)
+    </p>
+
+    <a class="anchor-no-button" href="{{resources.oauth_url}}" target="_blank">Connect to your domain</a>
+
+    <p>
+      Once you finish authorizing access, please paste the code you receive in
+      the box below.
+    </p>
+
+    <!-- TODO make this form be more useful -->
+    <form id="oauth-configuration-form" method="post" action="{{resources.setup_url}}">
+      <paper-input label="Domain" name="domain"></paper-input>
+      <paper-input label="OAuth Code" name="oauth_code"></paper-input>
+      <input type="hidden" name="_xsrf_token" value="{{xsrf_token()}}" />
+      <paper-button onclick="submitByFormId('oauth-configuration-form')" class="form-submit-button anchor-button" type="submit">
+        Submit
+      </paper-button>
+    </form>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'oauth-configuration-form',
+      properties: {
+        resources: {
+          type: Object,
+        },
+      },
+      isDomainConfigured: function(config) {
+        return config.domain && config.credentials; 
+      },
+    });
+  </script>
+</dom-module>

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -30,10 +30,6 @@ paper-tabs {
   margin-top: 16px;
 }
 
-#setup-form {
-  max-width: 800px;
-}
-
 #proxy-card-holder {
   max-width: 800px;
 }

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -1,6 +1,6 @@
 <link rel="import" href="bower_components/iron-form/iron-form.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
-<link rel="import" href="bower_components/paper-checkbox/paper-checkbox.html" /
+<link rel="import" href="bower_components/paper-checkbox/paper-checkbox.html" />
 <link rel="import" href="bower_components/paper-dialog-scrollable/paper-dialog-scrollable.html" />
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -12,8 +12,8 @@
   <!-- TODO: Add proxy server form here. -->
   <!-- TODO: Use paper material or  paper-display-template per PR comment.-->
   <paper-display-template resources="{{oauth_resources}}">
-    <oauth-configuration-form resources="{{oauth_resources}}">
-    </oauth-configuration-form>
+    <oauth-configuration resources="{{oauth_resources}}">
+    </oauth-configuration>
   </paper-display-template>
 
   <br>

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -42,5 +42,6 @@
       </paper-button>
     </div>
   </paper-card>
-
+  <!-- Remove this when it's properly in the base.html or provided any other ways. -->
+  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
 {% endblock %}

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -11,67 +11,9 @@
   <!-- TODO: Add user form here. -->
   <!-- TODO: Add proxy server form here. -->
   <!-- TODO: Use paper material or  paper-display-template per PR comment.-->
-  <paper-display-template resources="{{setup_resources}}">
-    <!-- TODO make a clear way to say you do not want to use Google apps -->
-    {% if not config.isConfigured %}
-      <p>
-        Hey there!  Welcome to the uProxy for Organizations management server!
-        To start, we want to get a bit of information from you to get everything
-        set up.
-      </p>
-
-      <p>
-        First of all, if you are planning on using this application with a Google
-        apps domain, we're going to need to get permission from you to access
-        that.  This will be used to keep the list of users in your domain in sync
-        with who is allowed to access the uProxy servers.  The credentials you
-        authorize will be shared by any administrators who log into this server.
-        If you do not plan on using a Google apps domain with this product, you
-        can just go straight to adding users.
-      </p>
-    {% else %}
-      <p>
-        You have already successfully configured this deployment!  If you want to
-        change the settings, you may do so below.  Please note: submitting the
-        form even without filling in any parameters will cause the previous saved
-        configuration to be lost.
-      </p>
-
-      {% if config.credentials and config.domain %}
-        <p>
-          This site is set up to work with the
-          <strong>{{config.domain}}</strong> domain.  If that is not correct,
-          please update the configuration.
-        </p>
-      {% else %}
-        <p>
-          This site is not set up to use any Google apps domain name, all users
-          will need to be manually input.
-        </p>
-      {% endif %}
-    {% endif %}
-
-    <p>
-      Please keep in mind that this is a much simpler version than what you
-      would actually expect to see in a finished version of the site.
-      Noteably, this page should include something about authenticating
-      yourself in the future (and actually include a way to skip)
-    </p>
-
-    <a class="anchor-no-button" href="{{ oauth_url }}" target="_blank">Connect to your domain</a>
-
-    <p>
-      Once you finish authorizing access, please paste the code you receive in
-      the box below.
-    </p>
-
-    <!-- TODO make this form be more useful -->
-    <form id="setup-form" method="post">
-      <paper-input label="Domain" name="domain"></paper-input>
-      <paper-input label="OAuth Code" name="oauth_code"></paper-input>
-      <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}" />
-      <paper-button onclick="submitByFormId('setup-form')" class="form-submit-button anchor-button" type="submit">Submit</paper-button>
-    </form>
+  <paper-display-template resources="{{oauth_resources}}">
+    <oauth-configuration-form resources="{{oauth_resources}}">
+    </oauth-configuration-form>
   </paper-display-template>
 
   <br>


### PR DESCRIPTION
The changes here are:
- Focus on the proper code structure of the new UI first.  Will work on actually polishing the UI later.
- Making the oauth configuration into a custom element.  This makes the setup page so much cleaner.
- Added polymer template conditionals to display the proper text, which previously was done in jinja.
- Added to_dict() for the config model, so that we can pass them into the custom element.  I will refactor this into a separate method later.
- There is currently the following error, which I think is due to xsrf.  Basically, the server is throwing this, even before processing anything else.  Have you seen something similar for the other pages?

```
403 - Forbidden
You don't have the permission to access the requested resource. It is either read-protected or not readable by the server.
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/52)

<!-- Reviewable:end -->
