### PR TITLE
Add proxy server form to the setup page

### DIFF
--- a/ufo/handlers/setup.py
+++ b/ufo/handlers/setup.py
@@ -7,8 +7,9 @@ import oauth2client
 
 import ufo
 from ufo.handlers import chrome_policy
-from ufo.services import oauth
 from ufo.handlers import user
+from ufo.handlers import proxy_server
+from ufo.services import oauth
 
 
 DOMAIN_INVALID_TEXT = 'Credentials for another domain.'
@@ -45,6 +46,8 @@ def setup():
   if flask.request.method == 'GET':
     user_resources_dict = user.get_user_resources_dict()
     user_resources_dict['hasAddFlow'] = False
+    proxy_server_resources_dict = proxy_server.get_proxy_resources_dict()
+    proxy_server_resources_dict['hasAddFlow'] = False
     oauth_resources_dict = _get_oauth_configration_resources_dict(config,
                                                                   oauth_url)
     policy_resources_dict = chrome_policy.get_policy_resources_dict()
@@ -53,6 +56,7 @@ def setup():
         'setup.html',
         oauth_url=oauth_url,
         policy_resources=json.dumps(policy_resources_dict),
+        proxy_server_resources=json.dumps(proxy_server_resources_dict),
         oauth_resources=json.dumps(oauth_resources_dict),
         user_resources=json.dumps(user_resources_dict))
 

--- a/ufo/services/xsrf.py
+++ b/ufo/services/xsrf.py
@@ -14,10 +14,13 @@ def xsrf_protect():
   """
   if ufo.app.config['TESTING']:
     return
-  if flask.request.method != 'GET':
-    token = flask.session.pop('_xsrf_token', None)
-    if not token or token != flask.request.form.get('_xsrf_token'):
-      flask.abort(403)
+
+  if flask.request.method == 'GET':
+    return
+
+  token = flask.session['_xsrf_token']
+  if not token or token != flask.request.form.get('_xsrf_token'):
+    flask.abort(403)
 
 def generate_xsrf_token():
   if '_xsrf_token' not in flask.session:

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -68,7 +68,12 @@
       parsePostResponse: function(e, detail) {
         this.sendServersJsonToList(detail.xhr.response);
         this.set('isSpinnerOn', false);
-        document.getElementById('serverModal').close();
+        serverModal = document.getElementById('serverModal');
+        if (serverModal) {
+          document.getElementById('serverModal').close();
+        } else {
+          document.getElementById('serverAddForm').reset();
+        }
       },
       sendServersJsonToList: function(updatedServersJson) {
         var listElem = document.getElementById(this.resources.listId);

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -7,10 +7,15 @@
     </user-add-tabs>
   </paper-display-template>
 
+  <br>
 
-  <!-- TODO: Add user form here. -->
-  <!-- TODO: Add proxy server form here. -->
-  <!-- TODO: Use paper material or  paper-display-template per PR comment.-->
+  <paper-display-template resources="{{proxy_server_resources}}">
+    <server-add-form resources="{{proxy_server_resources}}">
+    </server-add-form>
+  </paper-display-template>
+
+  <br>
+
   <paper-display-template resources="{{oauth_resources}}">
     <oauth-configuration resources="{{oauth_resources}}">
     </oauth-configuration>


### PR DESCRIPTION
There is a bit of work to make the proxy server form to, well, work.
- I changed the xsrf token to be per-session basis, instead of per-request basis.  This is a simple solution to the problem of folks adding multiple servers, one after another, on the setup page.  In which case, the token would have to be refreshed, and updated on all the forms of the setup page.  On a high-level, [per-session xsrf token actually is okay](http://security.stackexchange.com/questions/22903/why-refresh-csrf-token-per-form-request).
- Resetting the form upon response, instead of closing the modal window.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/53)

<!-- Reviewable:end -->
