### PR TITLE
Create a form container that will allow for icons on the left side.

### DIFF
--- a/ufo/static/formContainerWithLeftIcon.html
+++ b/ufo/static/formContainerWithLeftIcon.html
@@ -1,0 +1,40 @@
+<dom-module id="form-container-with-left-icon">
+  <style is="custom-style">
+    #container {
+      display: table;
+    }
+    #row {
+      display: table-row;
+    }
+    #left {
+      width: 300px;
+    }
+    #left, #right {
+      display: table-cell;
+      vertical-align: middle;
+      text-align: center;
+    }
+  </style>
+  <template>
+    <div id="container">
+      <div id="row">
+        <div id="left">
+          <img src="{{resources.addIconUrl}}">
+        </div>
+        <div id="right">
+          <content></content>
+        </div>
+      </div>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: 'form-container-with-left-icon',
+      properties: {
+        resources: {
+          type: Object,
+        },
+      },
+    });
+  </script>
+</dom-module>

--- a/ufo/static/formContainerWithLeftIcon.html
+++ b/ufo/static/formContainerWithLeftIcon.html
@@ -8,11 +8,11 @@
     }
     #left {
       width: 300px;
+      text-align: center;
+      vertical-align: middle;
     }
     #left, #right {
       display: table-cell;
-      vertical-align: middle;
-      text-align: center;
     }
   </style>
   <template>

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -3,15 +3,19 @@
 {% block body %}
 
   <paper-display-template resources="{{user_resources}}">
-    <user-add-tabs resources="{{user_resources}}">
-    </user-add-tabs>
+    <form-container-with-left-icon resources="{{user_resources}}">
+      <user-add-tabs resources="{{user_resources}}">
+      </user-add-tabs>
+    </form-container-with-left-icon>
   </paper-display-template>
 
   <br>
 
   <paper-display-template resources="{{proxy_server_resources}}">
-    <server-add-form resources="{{proxy_server_resources}}">
-    </server-add-form>
+    <form-container-with-left-icon resources="{{proxy_server_resources}}">
+      <server-add-form resources="{{proxy_server_resources}}">
+      </server-add-form>
+    </form-container-with-left-icon>
   </paper-display-template>
 
   <br>


### PR DESCRIPTION
- This is the simplest way I can think of to add an icon on the left side of the forms on the setup page.
- There are still issues to make this page look polished & awesome, but I think that is the outside the scope of this particular change.
- Feel free to let me know if there's anything improvements and that can done, some alignment tricks, css best practices, etc.

![screenshot from 2016-03-02 16 15 19](https://cloud.githubusercontent.com/assets/6977544/13480356/21f5f624-e092-11e5-8096-90d028fa2e34.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/56)

<!-- Reviewable:end -->
