### PR TITLE
Fix the body from bleeding into the header.

### DIFF
--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -146,7 +146,7 @@ paper-icon-item {
   /* This is used to make the body overlap a bit with the header.
      But, it is commented out because the body tends to bleed more and
      more into the header as the body gets longer and longer.
-     So, we need to find a more robust way to do this.
+     TODO: We need to find a more robust way to do this.
   margin-top: -80px;
   */
 }

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -143,5 +143,10 @@ paper-icon-item {
 }
 
 #main-holder {
+  /* This is used to make the body overlap a bit with the header.
+     But, it is commented out because the body tends to bleed more and
+     more into the header as the body gets longer and longer.
+     So, we need to find a more robust way to do this.
   margin-top: -80px;
+  */
 }


### PR DESCRIPTION
The setup page had a problem where the body was bleeding into the header.

The fix was simply to surround the paper-scroll-header-panel  with `<div></div>` tag.
(99% of the work was in troubleshooting.)

What the setup page looks like now.  I haved checked the new landing page to make sure this doesn't negatively affect it.
![screenshot from 2016-03-03 13 43 07](https://cloud.githubusercontent.com/assets/6977544/13510569/fb000046-e145-11e5-8919-e62521c22487.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/57)

<!-- Reviewable:end -->
