### PR TITLE
Make the chrome policy configurations into a custom component.

### DIFF
--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -43,6 +43,19 @@ def get_policy_resources_dict():
     'titleText': 'Chrome Policy',
   }
 
+
+def get_policy_configuration_resources_dict():
+  """Get the resources for the chrome policy configuration component.
+
+    Returns:
+      A dict of the resources for the chrome policy configuration component.
+  """
+  return {
+    'hasAddFlow': False,
+    'titleText': 'Chrome Policy Configurations',
+  }
+
+
 @ufo.app.route('/chromepolicy/')
 @ufo.setup_required
 def display_chrome_policy():

--- a/ufo/handlers/setup.py
+++ b/ufo/handlers/setup.py
@@ -51,10 +51,13 @@ def setup():
     oauth_resources_dict = _get_oauth_configration_resources_dict(config,
                                                                   oauth_url)
     policy_resources_dict = chrome_policy.get_policy_resources_dict()
+    policy_config_resources_dict = (
+        chrome_policy.get_policy_configuration_resources_dict())
 
     return flask.render_template(
         'setup.html',
         oauth_url=oauth_url,
+        policy_config_resources=json.dumps(policy_config_resources_dict),
         policy_resources=json.dumps(policy_resources_dict),
         proxy_server_resources=json.dumps(proxy_server_resources_dict),
         oauth_resources=json.dumps(oauth_resources_dict),

--- a/ufo/static/chromePolicyConfiguration.html
+++ b/ufo/static/chromePolicyConfiguration.html
@@ -1,0 +1,35 @@
+<link rel="import" href="bower_components/paper-button/paper-button.html" />
+
+<dom-module id="chrome-policy-configuration">
+  <style is="custom-style">
+    #policy-config-form {
+      margin-left: 25px;
+      margin-bottom: 25px;
+    }
+  </style>
+  <template>
+    <form id="policy-config-form" method="post" action="{{ url_for('edit_policy_config') }}">
+      <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="Enforce Proxy Server Check from Invitation Link" {% if enforce_proxy_server_validity %}checked{% endif %}></ufo-toggle-input>
+      <br>
+      <ufo-toggle-input input-name="enforce_network_jail" button-text="Enforce Network Jail Before Google Login" {% if enforce_network_jail %}checked{% endif %}></ufo-toggle-input>
+      <br>
+      <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}">
+      <paper-button class="anchor-button" onclick="submitByFormId('policy-config-form')" type="submit">
+        Save
+      </paper-button>
+    </form>
+  </template>
+  <script>
+    Polymer({
+      is: 'chrome-policy-configuration',
+      properties: {
+        resources: {
+          type: Object,
+        },
+      },
+      getXsrfToken: function() {
+        return document.getElementById('globalXsrf').value;
+      },
+    });
+  </script>
+</dom-module>

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -34,23 +34,11 @@
 
   <br>
 
-  <paper-card heading="Adjust Config Values">
-    <div class="card-content">
-      <form id="policy-config-form" method="post"
-        action="{{ url_for('edit_policy_config') }}">
-        <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="Enforce Proxy Server Check from Invitation Link" {% if enforce_proxy_server_validity %}checked{% endif %}></ufo-toggle-input>
-        <br>
-        <ufo-toggle-input input-name="enforce_network_jail" button-text="Enforce Network Jail Before Google Login" {% if enforce_network_jail %}checked{% endif %}></ufo-toggle-input>
-        <br>
-        <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}">
-      </form>
-    </div>
-    <div class="card-actions">
-      <paper-button onclick="submitByFormId('policy-config-form')" class="form-submit-button" type="submit">
-        Save
-      </paper-button>
-    </div>
-  </paper-card>
+  <paper-display-template resources="{{policy_config_resources}}">
+    <chrome-policy-configuration resources="{{policy_config_resources}}">
+    </chrome-policy-configuration>
+  </paper-display-template>
+
   <!-- Remove this when it's properly in the base.html or provided any other ways. -->
   <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
 {% endblock %}


### PR DESCRIPTION
- A custom component for the chrome policy configurations simplifies the setup page, as well as being consistent with other custom elements on the page.
- Elected to remove the paper-card, since we are displaying it as a custom element now.  Again, this is consistent with other custom elements on the setup page.  But if there is a reason to display this as paper-card, please do let me know.
- Fixed some alignment here, so the whole setup page looks tidy now.  See screenshot.
  ![screenshot from 2016-03-03 15 24 38](https://cloud.githubusercontent.com/assets/6977544/13513608/03cf2470-e157-11e5-8cc9-8a7c97e526a5.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/59)

<!-- Reviewable:end -->
