### PR TITLE
Extract the sectional header into a separate custom element.

### DIFF
--- a/ufo/static/headerContainer.html
+++ b/ufo/static/headerContainer.html
@@ -1,0 +1,37 @@
+<link rel="import" href="bower_components/iron-ajax/iron-ajax.html" />
+<link rel="import" href="bower_components/paper-material/paper-material.html" />
+<link rel="import" href="bower_components/paper-toolbar/paper-toolbar.html" />
+
+<dom-module id="header-container">
+  <template>
+    <div class="heading">
+      <paper-toolbar class="medium-tall">
+        <div class="middle flex">
+          <div class="horizontal center-justified layout">
+            <div class="title">{{resources.titleText}}</div>
+            <template is="dom-if" if="{{resources.hasAddFlow}}">
+              <add-item-button resources="{{resources}}"></add-item-button>
+            </template>
+          </div>
+        </div>
+      </paper-toolbar>
+    </div>
+    <div>
+      <content></content>
+    </div>
+    <template is="dom-if" if="{{resources.hasAddFlow}}">
+      <add-modal resources="{{resources}}"></add-modal>
+    </template>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'header-container',
+      properties: {
+        resources: {
+          type: Object,
+        },
+      },
+    });
+  </script>
+</dom-module>

--- a/ufo/static/paperDisplayTemplate.html
+++ b/ufo/static/paperDisplayTemplate.html
@@ -6,25 +6,8 @@
   <template>
     <div class="horizontal center-justified layout">
       <paper-material elevation="1">
-        <div class="heading">
-          <paper-toolbar class="medium-tall">
-            <div class="middle flex">
-              <div class="horizontal center-justified layout">
-                <div class="title">{{resources.titleText}}</div>
-                <template is="dom-if" if="{{resources.hasAddFlow}}">
-                  <add-item-button resources="{{resources}}"></add-item-button>
-                </template>
-              </div>
-            </div>
-          </paper-toolbar>
-        </div>
-        <div>
-          <content></content>
-        </div>
+        <content></content>
       </paper-material>
-      <template is="dom-if" if="{{resources.hasAddFlow}}">
-        <add-modal resources="{{resources}}"></add-modal>
-      </template>
     </div>
     <br>
   </template>

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -46,7 +46,7 @@ paper-scroll-header-panel {
 }
 
 paper-material {
-  background-color: #fafafa;
+  background-color: #ffffff;
 }
 
 paper-material:not(.dropdown-content), #jigsaw-logo-holder {

--- a/ufo/templates/landing2.html
+++ b/ufo/templates/landing2.html
@@ -2,16 +2,22 @@
 {% block title %}New Landing{% endblock %}
 {% block body %}
   <paper-display-template resources="{{user_resources}}">
-    <list-items resources="{{user_resources}}" id="userList">
-    </list-items>
+    <header-container resources="{{user_resources}}">
+      <list-items resources="{{user_resources}}" id="userList">
+      </list-items>
+    </header-container>
   </paper-display-template>
   <paper-display-template resources="{{proxy_resources}}">
-    <list-items resources="{{proxy_resources}}" id="proxyList">
-    </list-items>
+    <header-container resources="{{proxy_resources}}">
+      <list-items resources="{{proxy_resources}}" id="proxyList">
+      </list-items>
+    </header-container>
   </paper-display-template>
   <paper-display-template resources="{{policy_resources}}">
-    <chrome-policy resources="{{policy_resources}}">
-    </chrome-policy>
+    <header-container resources="{{policy_resources}}">
+      <chrome-policy resources="{{policy_resources}}">
+      </chrome-policy>
+    </header-container>
   </paper-display-template>
   <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
 {% endblock %}

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -21,22 +21,28 @@
   <br>
 
   <paper-display-template resources="{{oauth_resources}}">
-    <oauth-configuration resources="{{oauth_resources}}">
-    </oauth-configuration>
+    <header-container resources="{{oauth_resources}}">
+      <oauth-configuration resources="{{oauth_resources}}">
+      </oauth-configuration>
+    </header-container>
   </paper-display-template>
 
   <br>
 
   <paper-display-template resources="{{policy_resources}}">
-    <chrome-policy resources="{{policy_resources}}">
-    </chrome-policy>
+    <header-container resources="{{policy_resources}}">
+      <chrome-policy resources="{{policy_resources}}">
+      </chrome-policy>
+    </header-container>
   </paper-display-template>
 
   <br>
 
   <paper-display-template resources="{{policy_config_resources}}">
-    <chrome-policy-configuration resources="{{policy_config_resources}}">
-    </chrome-policy-configuration>
+    <header-container resources="{{policy_config_resources}}">
+      <chrome-policy-configuration resources="{{policy_config_resources}}">
+      </chrome-policy-configuration>
+    </header-container>
   </paper-display-template>
 
   <!-- Remove this when it's properly in the base.html or provided any other ways. -->


### PR DESCRIPTION
- This a very rough PR to test the general approach.
- The problem I'm trying to solve here is that sectional header (I don't know what to call it exactly) where the title text is being displayed is not necessary for the setup page. e.g. add user section has just a large add user icon on the left-side.  Please see the UI mock or the attached screenshot.
- The simplest and the cleanest way I can see to address this is to extract the header portion into a separate custom element, instead of adding more conditional templating inside paperDisplayTemplate.  This way, it's easy for someone to just apply the header element if they need it.
- What do you think of this general approach?  I am open to any other ways to solve this.  (Please don't mind the UI styling which still needs to be tightened.)
- I tested the new landing page with this change, and it works fine.

![screenshot from 2016-03-04 16 15 01](https://cloud.githubusercontent.com/assets/6977544/13543922/cbf8974c-e224-11e5-884b-cbb75ca99bf8.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/60)

<!-- Reviewable:end -->
