### PR TITLE
Search Page and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 instance/*
+sqlite:/*
 venv/*
 .project
 .pydevproject

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ class BaseConfiguration(object):
 
   SHARED_OAUTH_CLIENT_ID = '84596478403-6uffc6hu8v5b6v3nh0ski5cbptl02dsd.apps.googleusercontent.com'
   SHARED_OAUTH_CLIENT_SECRET = 'R5H27t1C-9enMO9ZNfxym3Gw'
+  WHOOSH_BASE = 'sqlite:///' + os.path.join(app.instance_path, 'search.db')
 
 class TestConfiguration(BaseConfiguration):
   """Configurations for testing the application in development."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 APScheduler==3.0.5
 Flask==0.10.1
-Flask-SQLAlchemy==2.1
+Flask-SQLAlchemy==1.0
 Flask-Testing==0.4.2
+flask-whooshalchemy==0.56
 google-api-python-client==1.4.2
 gunicorn==19.4.3
 httplib2==0.9.2

--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -1,5 +1,6 @@
 import flask
 from flask.ext import sqlalchemy
+from flask.ext import whooshalchemy
 import functools
 import os
 import sys
@@ -19,6 +20,7 @@ app.logger.setLevel(logging.INFO)
 
 if 'DATABASE_URL' in os.environ:
   app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['DATABASE_URL']
+  app.config['WHOOSH_BASE'] = os.environ['DATABASE_URL']
 
 # any instance-specific config the user wants to set, these override everything
 app.config.from_pyfile('application.cfg', silent=True)
@@ -30,6 +32,9 @@ db = sqlalchemy.SQLAlchemy(app)
 
 # DB needs to be defined before this point
 from ufo.database import models
+
+whooshalchemy.whoosh_index(app, models.User)
+whooshalchemy.whoosh_index(app, models.ProxyServer)
 
 @app.after_request
 def checkCredentialChange(response):

--- a/ufo/database/models.py
+++ b/ufo/database/models.py
@@ -51,7 +51,38 @@ class Model(ufo.db.Model):
 
   @classmethod
   def get_items_as_list_of_dict(cls):
-    items = cls.query.all()
+    """Retrieves a list of all the entities of this class in dictionary form.
+
+    Returns:
+      A list of entities in dictionary form from the database.
+    """
+    return cls.make_items_into_list_of_dict(cls.query.all())
+
+  @classmethod
+  def search(cls, search_text):
+    """Retrieves a list of the entities matching the search string.
+
+    This uses whoosh_search from the whoosh alchemy flask extension.
+
+    Args:
+      search_text: A string of the text to search for in the db.
+
+    Returns:
+      A list of entities in dictionary form matching the search string.
+    """
+    items = cls.query.whoosh_search(search_text, or_=True).all()
+    return cls.make_items_into_list_of_dict(items)
+
+  @classmethod
+  def make_items_into_list_of_dict(cls, items):
+    """Transforms a list of entities into a list of their dictionary form.
+
+    Args:
+      items: The entities in the database to transform.
+
+    Returns:
+      A list of the given entities in dictionary form.
+    """
     to_return = []
     for item in items:
       to_return.append(item.to_dict())
@@ -63,6 +94,7 @@ class Config(Model):
   configuration
   """
   __tablename__ = 'config'
+  __searchable__ = []
 
   id = ufo.db.Column(ufo.db.Integer, primary_key=True)
 
@@ -102,6 +134,7 @@ class User(Model):
   """Class for information about the users of the proxy servers
   """
   __tablename__ = "user"
+  __searchable__ = ['email', 'name', 'domain']
 
   id = ufo.db.Column(ufo.db.Integer, primary_key=True)
 
@@ -155,6 +188,7 @@ class ProxyServer(Model):
   """Class for information about the proxy servers
   """
   __tablename__ = "proxyserver"
+  __searchable__ = ['ip_address', 'name']
 
   id = ufo.db.Column(ufo.db.Integer, primary_key=True)
 

--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -30,4 +30,5 @@ def new_landing():
 from ufo.handlers import chrome_policy
 from ufo.handlers import proxy_server
 from ufo.handlers import setup
+from ufo.handlers import search
 from ufo.handlers import user

--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -23,7 +23,7 @@ def new_landing():
   return flask.render_template(
       'landing2.html',
       user_resources=json.dumps(user_resources_dict),
-      proxy_resources=json.dumps(proxy_resources_dict),
+      proxy_server_resources=json.dumps(proxy_resources_dict),
       policy_resources=json.dumps(policy_resources_dict))
 
 

--- a/ufo/handlers/search.py
+++ b/ufo/handlers/search.py
@@ -10,7 +10,8 @@ from ufo.handlers import user
 from ufo.handlers import proxy_server
 
 
-@ufo.app.route('/search/', methods=['GET'])
+# TODO(eholder): Add tests for these in a separate PR.
+@ufo.app.route('/searchpage/', methods=['GET'])
 @ufo.setup_required
 def search_page():
   """Renders the basic search page template.
@@ -19,8 +20,8 @@ def search_page():
     A rendered template of search.html.
   """
   search_text = json.loads(flask.request.args.get('search_text'))
-  user_items = _user_search_json_helper(search_text)
-  proxy_server_items = _server_search_json_helper(search_text)
+  user_items = _search_user(search_text)
+  proxy_server_items = _search_proxy_server(search_text)
 
   user_resources_dict = user.get_user_resources_dict()
   user_resources_dict['hasAddFlow'] = False
@@ -34,9 +35,9 @@ def search_page():
       user_items=json.dumps(user_items),
       proxy_server_items=json.dumps(proxy_server_items))
 
-@ufo.app.route('/search_results/', methods=['GET'])
+@ufo.app.route('/search/', methods=['GET'])
 @ufo.setup_required
-def search_json():
+def search():
   """Gets the database entities matching the search term.
 
   Returns:
@@ -44,26 +45,14 @@ def search_json():
     set to the proxy servers found.
   """
   search_text = json.loads(flask.request.args.get('search_text'))
-  results_json = _search_json_helper(search_text)
+  results_dict = {
+    'users': _search_user(search_text),
+    'servers': _search_proxy_server(search_text),
+  }
+  results_json = json.dumps((results_dict))
   return flask.Response(results_json, mimetype='application/json')
 
-def _search_json_helper(search_text):
-  """Gets the database entities matching the search term.
-
-  Args:
-    search_text: A string for the search term.
-
-  Returns:
-    A json object with users set to the users found and servers set to the
-    proxy servers found.
-  """
-  results_dict = {
-    'users': _user_search_json_helper(search_text),
-    'servers': _server_search_json_helper(search_text),
-  }
-  return json.dumps((results_dict))
-
-def _user_search_json_helper(search_text):
+def _search_user(search_text):
   """Gets the database users matching the search term.
 
   Args:
@@ -77,7 +66,7 @@ def _user_search_json_helper(search_text):
   }
   return results_dict
 
-def _server_search_json_helper(search_text):
+def _search_proxy_server(search_text):
   """Gets the database proxy servers matching the search term.
 
   Args:

--- a/ufo/handlers/search.py
+++ b/ufo/handlers/search.py
@@ -3,8 +3,6 @@
 import json
 
 import flask
-# Renaming search to sa_search to avoid name conflicts.
-from sqlalchemy_searchable import search as sa_search
 
 import ufo
 from ufo.database import models

--- a/ufo/handlers/search.py
+++ b/ufo/handlers/search.py
@@ -21,16 +21,31 @@ def search_page():
   search_text = json.loads(flask.request.args.get('search_text'))
   user_resources_dict = user.get_user_resources_dict()
   user_resources_dict['hasAddFlow'] = False
-  user_results = models.User.search(search_text)
-  user_items = json.dumps(({'items': user_results}))
   proxy_server_resources_dict = proxy_server.get_proxy_resources_dict()
   proxy_server_resources_dict['hasAddFlow'] = False
-  proxy_server_results = models.ProxyServer.search(search_text)
-  proxy_server_items = json.dumps(({'items': proxy_server_results}))
 
   return flask.render_template(
       'search.html',
       user_resources=json.dumps(user_resources_dict),
-      user_items=user_items,
-      proxy_server_resources=json.dumps(proxy_server_resources_dict),
-      proxy_server_items=proxy_server_items)
+      proxy_server_resources=json.dumps(proxy_server_resources_dict))
+
+@ufo.app.route('/search_results/', methods=['GET'])
+@ufo.setup_required
+def search_json():
+  """Gets the database entities matching the search term.
+
+  Returns:
+    A json object with users set to the users found and servers set to the
+    proxy servers found.
+  """
+  search_text = json.loads(flask.request.args.get('search_text'))
+  results_dict = {
+    'users': {
+      'items': models.User.search(search_text),
+    },
+    'servers': {
+      'items': models.ProxyServer.search(search_text),
+    },
+  }
+  results_json = json.dumps((results_dict))
+  return flask.Response(results_json, mimetype='application/json')

--- a/ufo/handlers/search.py
+++ b/ufo/handlers/search.py
@@ -19,6 +19,9 @@ def search_page():
     A rendered template of search.html.
   """
   search_text = json.loads(flask.request.args.get('search_text'))
+  user_items = _user_search_json_helper(search_text)
+  proxy_server_items = _server_search_json_helper(search_text)
+
   user_resources_dict = user.get_user_resources_dict()
   user_resources_dict['hasAddFlow'] = False
   proxy_server_resources_dict = proxy_server.get_proxy_resources_dict()
@@ -27,7 +30,9 @@ def search_page():
   return flask.render_template(
       'search.html',
       user_resources=json.dumps(user_resources_dict),
-      proxy_server_resources=json.dumps(proxy_server_resources_dict))
+      proxy_server_resources=json.dumps(proxy_server_resources_dict),
+      user_items=json.dumps(user_items),
+      proxy_server_items=json.dumps(proxy_server_items))
 
 @ufo.app.route('/search_results/', methods=['GET'])
 @ufo.setup_required
@@ -35,17 +40,53 @@ def search_json():
   """Gets the database entities matching the search term.
 
   Returns:
+    A flask response json object with users set to the users found and servers
+    set to the proxy servers found.
+  """
+  search_text = json.loads(flask.request.args.get('search_text'))
+  results_json = _search_json_helper(search_text)
+  return flask.Response(results_json, mimetype='application/json')
+
+def _search_json_helper(search_text):
+  """Gets the database entities matching the search term.
+
+  Args:
+    search_text: A string for the search term.
+
+  Returns:
     A json object with users set to the users found and servers set to the
     proxy servers found.
   """
-  search_text = json.loads(flask.request.args.get('search_text'))
   results_dict = {
-    'users': {
-      'items': models.User.search(search_text),
-    },
-    'servers': {
-      'items': models.ProxyServer.search(search_text),
-    },
+    'users': _user_search_json_helper(search_text),
+    'servers': _server_search_json_helper(search_text),
   }
-  results_json = json.dumps((results_dict))
-  return flask.Response(results_json, mimetype='application/json')
+  return json.dumps((results_dict))
+
+def _user_search_json_helper(search_text):
+  """Gets the database users matching the search term.
+
+  Args:
+    search_text: A string for the search term.
+
+  Returns:
+    A dict object with items set to the users found.
+  """
+  results_dict = {
+    'items': models.User.search(search_text),
+  }
+  return results_dict
+
+def _server_search_json_helper(search_text):
+  """Gets the database proxy servers matching the search term.
+
+  Args:
+    search_text: A string for the search term.
+
+  Returns:
+    A dict object with items set to the proxy servers found.
+  """
+  results_dict = {
+    'items': models.ProxyServer.search(search_text),
+  }
+  return results_dict

--- a/ufo/handlers/search.py
+++ b/ufo/handlers/search.py
@@ -1,0 +1,38 @@
+"""Search module which provides handlers to locate users and proxy servers."""
+
+import json
+
+import flask
+# Renaming search to sa_search to avoid name conflicts.
+from sqlalchemy_searchable import search as sa_search
+
+import ufo
+from ufo.database import models
+from ufo.handlers import user
+from ufo.handlers import proxy_server
+
+
+@ufo.app.route('/search/', methods=['GET'])
+@ufo.setup_required
+def search_page():
+  """Renders the basic search page template.
+
+  Returns:
+    A rendered template of search.html.
+  """
+  search_text = json.loads(flask.request.args.get('search_text'))
+  user_resources_dict = user.get_user_resources_dict()
+  user_resources_dict['hasAddFlow'] = False
+  user_results = models.User.search(search_text)
+  user_items = json.dumps(({'items': user_results}))
+  proxy_server_resources_dict = proxy_server.get_proxy_resources_dict()
+  proxy_server_resources_dict['hasAddFlow'] = False
+  proxy_server_results = models.ProxyServer.search(search_text)
+  proxy_server_items = json.dumps(({'items': proxy_server_results}))
+
+  return flask.render_template(
+      'search.html',
+      user_resources=json.dumps(user_resources_dict),
+      user_items=user_items,
+      proxy_server_resources=json.dumps(proxy_server_resources_dict),
+      proxy_server_items=proxy_server_items)

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -137,7 +137,7 @@ def get_user_resources_dict():
   """
   return {
     'searchPageUrl': flask.url_for('search_page'),
-    'searchJsonUrl': flask.url_for('search_json'),
+    'searchJsonUrl': flask.url_for('search'),
     'addUrl': flask.url_for('add_user'),
     'addIconUrl': flask.url_for('static', filename='img/add-users.svg'),
     'addText': 'Add Users',

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -136,6 +136,7 @@ def get_user_resources_dict():
       A dict of the resources for the user component.
   """
   return {
+    'searchUrl': flask.url_for('search_json'),
     'addUrl': flask.url_for('add_user'),
     'addIconUrl': flask.url_for('static', filename='img/add-users.svg'),
     'addText': 'Add Users',

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -211,7 +211,7 @@ def user_list():
   """Retrieves a list of the users currently in the db.
 
   Returns:
-    A json object with 'users' set to the list of users in the db.
+    A json object with 'items' set to the list of users in the db.
   """
   users_json = json.dumps(({'items': models.User.get_items_as_list_of_dict()}))
   return flask.Response(users_json, mimetype='application/json')

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -136,7 +136,8 @@ def get_user_resources_dict():
       A dict of the resources for the user component.
   """
   return {
-    'searchUrl': flask.url_for('search_json'),
+    'searchPageUrl': flask.url_for('search_page'),
+    'searchJsonUrl': flask.url_for('search_json'),
     'addUrl': flask.url_for('add_user'),
     'addIconUrl': flask.url_for('static', filename='img/add-users.svg'),
     'addText': 'Add Users',

--- a/ufo/static/listItems.html
+++ b/ufo/static/listItems.html
@@ -39,7 +39,7 @@
     <template is="dom-if" if="{{loading}}">
       <paper-spinner active$={{loading}}></paper-spinner>
     </template>
-    <iron-ajax auto
+    <iron-ajax auto$="[[autoGet]]"
       url="{{resources.listUrl}}"
       method="GET"
       handle-as="json"
@@ -109,6 +109,11 @@
         characterLimit: {
           type: Number,
           value: 25,
+        },
+        autoGet: {
+          type: Boolean,
+          value: false,
+          notify: true,
         },
       },
       _limitCharacters: function(text) {

--- a/ufo/static/listItems.html
+++ b/ufo/static/listItems.html
@@ -141,6 +141,9 @@
       setAjaxResponse: function(response) {
         this.set('ajaxResponse', response);
       },
+      resendRequest: function() {
+        this.$.getItemsAjax.generateRequest();
+      },
       enableSpinner: function() {
         this.set('loading', true);
       },

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -99,7 +99,7 @@ paper-dialog-scrollable > div {
   font-weight: 500!important;
 }
 
-.search .paper-input-container.underline, .custom-dropdown .paper-input-container.underline {
+.custom-dropdown .paper-input-container.underline {
   display: none;
 }
 
@@ -125,10 +125,6 @@ paper-dialog-scrollable > div {
 
 #main-toolbar-title {
   color: white!important;
-}
-
-#search-bar {
-  background-color: #4DB6AB;
 }
 
 #username-and-menu {

--- a/ufo/static/ufoSearchBar.html
+++ b/ufo/static/ufoSearchBar.html
@@ -23,7 +23,7 @@
   </style>
   <template>
 
-    <form is="iron-form" method="GET" action="{{userResources.searchUrl}}" loading="{{loading}}" last-response="{{searchJson}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseSearchResponse" id="searchForm" content-type="application/json">
+    <form is="iron-form" method="GET" action="{{userResources.searchJsonUrl}}" loading="{{loading}}" last-response="{{searchJson}}" on-iron-form-presubmit="presubmit" on-iron-form-response="parseSearchResponse" id="searchForm" content-type="application/json">
       <paper-input id="searchBar" no-label-float name="search_input" value="{{searchText}}">
         <paper-icon-button icon="search" prefix on-tap="submitForm"></paper-icon-button>
         <paper-icon-button icon="arrow-back" suffix id="suffix" class="hideSuffix" on-tap="resetLists"></paper-icon-button>
@@ -59,8 +59,18 @@
           notify: true,
         },
       },
-      enableSpinner: function() {
+      presubmit: function() {
+        var userList = document.getElementById(this.userResources.listId);
+        var serverList = document.getElementById(
+          this.proxyServerResources.listId);
+        if (!userList && !serverList) {
+          var queryString = "?search_text=" + this.$.hiddenSearch.value;
+          var locationString = this.userResources.searchPageUrl + queryString;
+          window.location.href = locationString;
+        }
         this.set('loading', true);
+        this.$.suffix.className = this.$.suffix.className.replace(
+          'hideSuffix', 'showSuffix');
       },
       submitForm: function(e, details) {
         var elem = e.target;
@@ -85,11 +95,6 @@
             this.proxyServerResources.listId);
         }
         this.set('loading', false);
-        console.log(this.$.suffix);
-        console.log(this.$.suffix.className);
-        this.$.suffix.className = this.$.suffix.className.replace(
-          'hideSuffix', 'showSuffix');
-        console.log(this.$.suffix.className);
       },
       sendJsonToList: function(updatedJson, elementId) {
         var listElem = document.getElementById(elementId);
@@ -107,11 +112,8 @@
         if (serverList) {
           serverList.resendRequest();
         }
-        console.log(this.$.suffix);
-        console.log(this.$.suffix.className);
         this.$.suffix.className = this.$.suffix.className.replace(
           'showSuffix', 'hideSuffix');
-        console.log(this.$.suffix.className);
       },
     });
   </script>

--- a/ufo/static/ufoSearchBar.html
+++ b/ufo/static/ufoSearchBar.html
@@ -1,0 +1,118 @@
+<link rel="import" href="bower_components/iron-form/iron-form.html" />
+<link rel="import" href="bower_components/iron-icons/iron-icons.html" />
+<link rel="import" href="bower_components/paper-icon-button/paper-icon-button.html" />
+<link rel="import" href="bower_components/paper-input/paper-input.html" />
+<link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+
+<dom-module id="ufo-search-bar">
+  <style is="custom-style">
+    #searchBar {
+      background-color: #4DB6AB;
+      border-radius: 5px;
+      --paper-input-container-input-color: white;
+      --paper-input-container-color: rgba(0,0,0,0.0)!important;
+      --paper-input-container-focus-color: rgba(0,0,0,0.0)!important;
+      --paper-input-container-invalid-color: rgba(0,0,0,0.0)!important;
+    }
+    .hideSuffix {
+      display: none;
+    }
+    .showSuffix {
+      display: block;
+    }
+  </style>
+  <template>
+
+    <form is="iron-form" method="GET" action="{{userResources.searchUrl}}" loading="{{loading}}" last-response="{{searchJson}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseSearchResponse" id="searchForm" content-type="application/json">
+      <paper-input id="searchBar" no-label-float name="search_input" value="{{searchText}}">
+        <paper-icon-button icon="search" prefix on-tap="submitForm"></paper-icon-button>
+        <paper-icon-button icon="arrow-back" suffix id="suffix" class="hideSuffix" on-tap="resetLists"></paper-icon-button>
+      </paper-input>
+      <input type="hidden" id="hiddenSearch" name="search_text" value="&quot;{{searchText}}&quot;">
+    </form>
+    <template is="dom-if" if="{{loading}}">
+      <paper-spinner active$={{loading}}></paper-spinner>
+    </template>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'ufo-search-bar',
+      properties: {
+        userResources: {
+          type: Object,
+        },
+        proxyServerResources: {
+          type: Object,
+        },
+        loading: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
+        searchText: {
+          type: String,
+          notify: true,
+        },
+        searchJson: {
+          type: Object,
+          notify: true,
+        },
+      },
+      enableSpinner: function() {
+        this.set('loading', true);
+      },
+      submitForm: function(e, details) {
+        var elem = e.target;
+        while (elem.tagName.toLowerCase() != 'form') {
+          elem = elem.parentElement;
+          if (elem == document.body) {
+            break;
+          }
+        }
+        if (elem.tagName.toLowerCase() != 'form') {
+          return;
+        }
+        elem.submit();
+      },
+      parseSearchResponse: function(e, details) {
+        var searchJson = details.xhr.response;
+        if (searchJson.users) {
+          this.sendJsonToList(searchJson.users, this.userResources.listId);
+        }
+        if (searchJson.servers) {
+          this.sendJsonToList(searchJson.servers,
+            this.proxyServerResources.listId);
+        }
+        this.set('loading', false);
+        console.log(this.$.suffix);
+        console.log(this.$.suffix.className);
+        this.$.suffix.className = this.$.suffix.className.replace(
+          'hideSuffix', 'showSuffix');
+        console.log(this.$.suffix.className);
+      },
+      sendJsonToList: function(updatedJson, elementId) {
+        var listElem = document.getElementById(elementId);
+        if (listElem) {
+          listElem.setAjaxResponse(updatedJson);
+        }
+      },
+      resetLists: function(e, details) {
+        var userList = document.getElementById(this.userResources.listId);
+        if (userList) {
+          userList.resendRequest();
+        }
+        var serverList = document.getElementById(
+          this.proxyServerResources.listId);
+        if (serverList) {
+          serverList.resendRequest();
+        }
+        console.log(this.$.suffix);
+        console.log(this.$.suffix.className);
+        this.$.suffix.className = this.$.suffix.className.replace(
+          'showSuffix', 'hideSuffix');
+        console.log(this.$.suffix.className);
+      },
+    });
+  </script>
+</dom-module>

--- a/ufo/static/ufoSearchBar.html
+++ b/ufo/static/ufoSearchBar.html
@@ -114,6 +114,7 @@
         }
         this.$.suffix.className = this.$.suffix.className.replace(
           'showSuffix', 'hideSuffix');
+        this.set('searchText', '');
       },
     });
   </script>

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -19,6 +19,9 @@
     width: 20px;
     --iron-icon-fill-color: #009788;
   }
+  .verticalSpacer {
+    height: 20px;
+  }
 </style>
 <body class="fullbleed layout vertical">
   <paper-scroll-header-panel>
@@ -28,9 +31,12 @@
           <img src="{{ url_for('static', filename='img/ufo-logo.svg') }}" alt="uProxy Logo" height="80" width="80">
         </div>
         <div class="flex"></div>
-        <paper-input class="center flex-4 search" id="search-bar">
-          <paper-icon-button icon="search" prefix></paper-icon-button>
-        </paper-input>
+        <div class="vertical layout flex-4">
+          <div class="verticalSpacer"><p></div>
+          <ufo-search-bar class="flex" user-resources="{{user_resources}}" proxy-server-resources="{{proxy_server_resources}}">
+          </ufo-search-bar>
+          <div class="verticalSpacer"></div>
+        </div>
         <div class="flex"></div>
         <paper-dropdown-menu label="foo" id="username-and-menu" class="custom-dropdown flex">
           <paper-listbox class="dropdown-content">

--- a/ufo/templates/landing2.html
+++ b/ufo/templates/landing2.html
@@ -7,9 +7,9 @@
       </list-items>
     </header-container>
   </paper-display-template>
-  <paper-display-template resources="{{proxy_resources}}">
-    <header-container resources="{{proxy_resources}}">
-      <list-items resources="{{proxy_resources}}" id="proxyList" auto-get=true>
+  <paper-display-template resources="{{proxy_server_resources}}">
+    <header-container resources="{{proxy_server_resources}}">
+      <list-items resources="{{proxy_server_resources}}" id="proxyList" auto-get=true>
       </list-items>
     </header-container>
   </paper-display-template>

--- a/ufo/templates/landing2.html
+++ b/ufo/templates/landing2.html
@@ -2,11 +2,11 @@
 {% block title %}New Landing{% endblock %}
 {% block body %}
   <paper-display-template resources="{{user_resources}}">
-    <list-items resources="{{user_resources}}" id="userList">
+    <list-items resources="{{user_resources}}" id="userList" auto-get=true>
     </list-items>
   </paper-display-template>
   <paper-display-template resources="{{proxy_resources}}">
-    <list-items resources="{{proxy_resources}}" id="proxyList">
+    <list-items resources="{{proxy_resources}}" id="proxyList" auto-get=true>
     </list-items>
   </paper-display-template>
   <paper-display-template resources="{{policy_resources}}">

--- a/ufo/templates/search.html
+++ b/ufo/templates/search.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% block title %}Search Results{% endblock %}
 {% block body %}
+<!-- TODO(eholder): Verify this page will/will not be needed according
+                    to John Cassidy and remove or keep as appropriate. -->
   <paper-display-template resources="{{user_resources}}">
     <header-container resources="{{user_resources}}">
       <list-items resources="{{user_resources}}" id="userList" ajax-response="{{user_items}}">

--- a/ufo/templates/search.html
+++ b/ufo/templates/search.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Search Results{% endblock %}
+{% block body %}
+  <paper-display-template resources="{{user_resources}}">
+    <list-items resources="{{user_resources}}" id="userList" ajax-response="{{user_items}}">
+    </list-items>
+  </paper-display-template>
+  <paper-display-template resources="{{proxy_server_resources}}">
+    <list-items resources="{{proxy_server_resources}}" id="proxyList" ajax-response="{{proxy_server_items}}">
+    </list-items>
+  </paper-display-template>
+  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
+{% endblock %}


### PR DESCRIPTION
This PR encompasses two different search flows, which we can decide on preference for later. On the landing page, searching will give results directly in the user and server lists as well as popup a back button to return the view to what is expected. On the setup page, searching will redirect to the new search page, with results being displayed there. We could easily make the user page redirect as well, but I'm honestly not sure which is the best approach. John should be able to better direct us on this. For now, I would like to submit both and iterate on them as necessary.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/61)

<!-- Reviewable:end -->
