### PR TITLE
Polish the setup page UI.

### DIFF
--- a/ufo/static/chromePolicy.html
+++ b/ufo/static/chromePolicy.html
@@ -30,11 +30,13 @@
         click override to edit Force Installation or Configure's values.
         Finally, click Save.
       </p></paper-item>
-      <paper-item>
-        <a href="{{resources.download_chrome_policy}}" download="{{resources.policy_filename}}">
-          <paper-button class="anchor-button"><iron-icon icon="file-download"></iron-icon> Download Policy</paper-button>
-        </a>
-      </paper-item>
+      <div class="buttons">
+        <paper-item>
+          <a href="{{resources.download_chrome_policy}}" download="{{resources.policy_filename}}">
+            <paper-button class="anchor-button"><iron-icon icon="file-download"></iron-icon> Download Policy</paper-button>
+          </a>
+        </paper-item>
+      </div>
     </paper-listbox>
   </template>
 

--- a/ufo/static/chromePolicyConfiguration.html
+++ b/ufo/static/chromePolicyConfiguration.html
@@ -14,9 +14,11 @@
       <ufo-toggle-input input-name="enforce_network_jail" button-text="Enforce Network Jail Before Google Login" {% if enforce_network_jail %}checked{% endif %}></ufo-toggle-input>
       <br>
       <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}">
-      <paper-button class="anchor-button" onclick="submitByFormId('policy-config-form')" type="submit">
-        Save
-      </paper-button>
+      <div class="buttons">
+        <paper-button class="anchor-button" onclick="submitByFormId('policy-config-form')" type="submit">
+          Save
+        </paper-button>
+      </div>
     </form>
   </template>
   <script>

--- a/ufo/static/formContainerWithLeftIcon.html
+++ b/ufo/static/formContainerWithLeftIcon.html
@@ -2,6 +2,7 @@
   <style is="custom-style">
     #container {
       display: table;
+      width: 100%
     }
     #row {
       display: table-row;
@@ -10,16 +11,32 @@
       width: 300px;
       text-align: center;
       vertical-align: middle;
+      border-right: 1px solid #e5e5e5;
+    }
+    #right {
+      padding-top: 10px;
+      padding-bottom: 10px;
+      padding-left: 25px;
+      padding-right: 25px;
     }
     #left, #right {
       display: table-cell;
+    }
+    #description {
+      font-size: 15px;
+      font-weight: bold;
     }
   </style>
   <template>
     <div id="container">
       <div id="row">
         <div id="left">
-          <img src="{{resources.addIconUrl}}">
+          <div>
+            <img src="{{resources.addIconUrl}}">
+          </div>
+          <div id="description">
+            {{resources.addText}}
+          </div>
         </div>
         <div id="right">
           <content></content>

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -4,75 +4,97 @@
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />>
 
 <dom-module id="oauth-configuration">
+  <style is="custom-style">
+    #oauth-configuration-form {
+      margin-left: 25px;
+      margin-bottom: 25px;
+    }
+  </style>
   <template>
     <!-- TODO: Make a clear way to say you do not want to use Google apps. -->
     <!-- TODO: Extract these strings so they can be i18n. -->
-    <template is="dom-if" if="{{!resources.config.is_configured}}">
-      <p>
-        Hey there!  Welcome to the uProxy for Organizations management server!
-        To start, we want to get a bit of information from you to get everything
-        set up.
-      </p>
-
-      <p>
-        First of all, if you are planning on using this application with a Google
-        apps domain, we're going to need to get permission from you to access
-        that.  This will be used to keep the list of users in your domain in sync
-        with who is allowed to access the uProxy servers.  The credentials you
-        authorize will be shared by any administrators who log into this server.
-        If you do not plan on using a Google apps domain with this product, you
-        can just go straight to adding users.
-      </p>
-    </template>
-
-    <template is="dom-if" if="{{resources.config.is_configured}}">
-      <p>
-        You have already successfully configured this deployment!  If you want to
-        change the settings, you may do so below.  Please note: submitting the
-        form even without filling in any parameters will cause the previous saved
-        configuration to be lost.
-      </p>
-
-      <template is="dom-if" if="{{isDomainConfigured(resources.config)}}">
-        <p>
-          This site is set up to work with the
-          <strong>{{resources.config.domain}}</strong> domain.  If that is not correct,
-          please update the configuration.
-        </p>
+    <paper-listbox id="chrome-policy">
+      <template is="dom-if" if="{{!resources.config.is_configured}}">
+        <paper-item>
+          <p>
+            Hey there!  Welcome to the uProxy for Organizations management server!
+            To start, we want to get a bit of information from you to get everything
+            set up.
+          </p>
+          <p>
+            First of all, if you are planning on using this application with a Google
+            apps domain, we're going to need to get permission from you to access
+            that.  This will be used to keep the list of users in your domain in sync
+            with who is allowed to access the uProxy servers.  The credentials you
+            authorize will be shared by any administrators who log into this server.
+            If you do not plan on using a Google apps domain with this product, you
+            can just go straight to adding users.
+          </p>
+        </paper-item>
       </template>
 
-      <template is="dom-if" if="{{!isDomainConfigured(resources.config)}}">
-        <p>
-          This site is not set up to use any Google apps domain name, all users
-          will need to be manually input.
-        </p>
+      <template is="dom-if" if="{{resources.config.is_configured}}">
+        <paper-item>
+          <p>
+            You have already successfully configured this deployment!  If you want to
+            change the settings, you may do so below.  Please note: submitting the
+            form even without filling in any parameters will cause the previous saved
+            configuration to be lost.
+          </p>
+        </paper-item>
+  
+        <template is="dom-if" if="{{isDomainConfigured(resources.config)}}">
+          <paper-item>
+            <p>
+              This site is set up to work with the
+              <strong>{{resources.config.domain}}</strong> domain.  If that is not correct,
+              please update the configuration.
+            </p>
+          </paper-item>
+        </template>
+  
+        <template is="dom-if" if="{{!isDomainConfigured(resources.config)}}">
+          <paper-item>
+            <p>
+              This site is not set up to use any Google apps domain name, all users
+              will need to be manually input.
+            </p>
+          </paper-item>
+        </template>
       </template>
 
-    </template>
+      <paper-item>
+        <p>
+          Please keep in mind that this is a much simpler version than what you
+          would actually expect to see in a finished version of the site.
+          Noteably, this page should include something about authenticating
+          yourself in the future (and actually include a way to skip)
+        </p>
+      </paper-item>
 
-    <p>
-      Please keep in mind that this is a much simpler version than what you
-      would actually expect to see in a finished version of the site.
-      Noteably, this page should include something about authenticating
-      yourself in the future (and actually include a way to skip)
-    </p>
+      <paper-item>
+        <a class="anchor-no-button" href="{{resources.oauth_url}}" target="_blank">Connect to your domain</a>
+      </paper-item>
 
-    <a class="anchor-no-button" href="{{resources.oauth_url}}" target="_blank">Connect to your domain</a>
-
-    <p>
-      Once you finish authorizing access, please paste the code you receive in
-      the box below.
-    </p>
-
-    <!-- TODO make this form be more useful -->
-    <form id="oauth-configuration-form" method="post" action="{{resources.setup_url}}">
-      <paper-input label="Domain" name="domain"></paper-input>
-      <paper-input label="OAuth Code" name="oauth_code"></paper-input>
-      <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
-      <paper-button onclick="submitByFormId('oauth-configuration-form')" class="form-submit-button anchor-button" type="submit">
-        Submit
-      </paper-button>
-    </form>
+      <paper-item>
+         <p>
+           Once you finish authorizing access, please paste the code you receive in
+           the box below.
+         </p>
+       </paper-item>
+  
+      <!-- TODO make this form be more useful -->
+      <form id="oauth-configuration-form" method="post" action="{{resources.setup_url}}">
+        <paper-input label="Domain" name="domain"></paper-input>
+        <paper-input label="OAuth Code" name="oauth_code"></paper-input>
+        <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
+        <div class="buttons">
+          <paper-button onclick="submitByFormId('oauth-configuration-form')" class="form-submit-button anchor-button" type="submit">
+            Submit
+          </paper-button>
+        </div>
+      </form>
+    </paper-listbox>
   </template>
 
   <script>

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -8,7 +8,7 @@ paper-card {
 }
 
 form {
-  max-width: 800px;
+  max-width: 90%;
 }
 
 paper-tab {
@@ -109,6 +109,11 @@ paper-dialog-scrollable > div {
 
 .paper-input-container.label-is-highlighted label {
   color: #25CFB9!important;
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
 }
 
 #jigsaw-logo {

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -18,9 +18,7 @@
       background-color: white;
     }
     #ironPagesHolder {
-      background: #EEE;
       margin-bottom: 0px;
-      border-bottom: 24px solid #EEE;
       padding: 0px 24px;
     }
     #spinner {

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -18,7 +18,7 @@
       background-color: white;
     }
     #ironPagesHolder {
-      margin-bottom: 0px;
+      margin-bottom: 24px;
       padding: 0px 24px;
     }
     #spinner {


### PR DESCRIPTION
This is a collection of small changes to polish the UI on the setup page:  alignments, spacing, border, additional texts, etc.  The goal is to start making the page look like what's in the UI mock.  See screenshot below.

I have tested the new landing page, to make sure it's not adversely affected.  However, there is one change that affects the landing page, i.e. change the overlay form background from grey to white.  This is because the form needs to have a white background on the setup page, but not in the landing page overlay.  I didn't see any simple way to add logic to control the styling, so I just made the form background to be white everywhere.  Actually, this looks better on top of the dark overlay.  See 2nd screenshot below.

![screenshot from 2016-03-14 15 14 37](https://cloud.githubusercontent.com/assets/6977544/13761739/abc99fcc-e9f7-11e5-96e2-f9969ae694f3.png)

![screenshot from 2016-03-14 15 15 03](https://cloud.githubusercontent.com/assets/6977544/13761744/b096d222-e9f7-11e5-999d-cb8dfc364da5.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/62)

<!-- Reviewable:end -->
