### PR TITLE
Upgrade Chrome Policy Config to Use JSON and AJAX

### DIFF
--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -28,6 +28,21 @@ def _make_chrome_policy_json():
 
   return json.dumps(policy_dictionary)
 
+def _make_settings_json():
+  """Generates the json string of all settings based on values in the db.
+
+  Returns:
+    A json string of current server settings.
+  """
+  config = ufo.get_user_config()
+
+  settings_dictionary = {
+      "enforce_network_jail": config.network_jail_until_google_auth,
+      "enforce_proxy_server_validity": config.proxy_server_validity,
+  }
+
+  return json.dumps(settings_dictionary)
+
 
 def get_policy_resources_dict():
   """Get the resources for the chrome policy component.
@@ -53,7 +68,11 @@ def get_policy_configuration_resources_dict():
   return {
     'hasAddFlow': False,
     'titleText': 'Chrome Policy Configurations',
+    'getSettingsUrl': flask.url_for('get_settings'),
     'editUrl': flask.url_for('edit_policy_config'),
+    'proxyValidityText': 'Enforce Proxy Server Check from Invitation Link',
+    'networkJailText': 'Enforce Network Jail Before Google Login',
+    'saveText': 'Save',
   }
 
 
@@ -72,6 +91,17 @@ def display_chrome_policy():
       'chrome_policy.html', policy_json=policy_json,
       enforce_proxy_server_validity=config.proxy_server_validity,
       enforce_network_jail=config.network_jail_until_google_auth)
+
+
+@ufo.app.route('/settings/', methods=['GET'])
+@ufo.setup_required
+def get_settings():
+  """Gets the current settings as a json object.
+
+  Returns:
+    A flask response with the json settings.
+  """
+  return flask.Response(_make_settings_json(), mimetype='application/json')
 
 
 @ufo.app.route('/chromepolicy/download/')
@@ -109,4 +139,4 @@ def edit_policy_config():
 
   config.save()
 
-  return flask.redirect(flask.url_for('display_chrome_policy'))
+  return flask.redirect(flask.url_for('get_settings'))

--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -28,21 +28,6 @@ def _make_chrome_policy_json():
 
   return json.dumps(policy_dictionary)
 
-def _make_settings_json():
-  """Generates the json string of all settings based on values in the db.
-
-  Returns:
-    A json string of current server settings.
-  """
-  config = ufo.get_user_config()
-
-  settings_dictionary = {
-      "enforce_network_jail": config.network_jail_until_google_auth,
-      "enforce_proxy_server_validity": config.proxy_server_validity,
-  }
-
-  return json.dumps(settings_dictionary)
-
 
 def get_policy_resources_dict():
   """Get the resources for the chrome policy component.
@@ -56,23 +41,6 @@ def get_policy_resources_dict():
     'hasAddFlow': False,
     'policy_filename': 'chrome_policy.json',
     'titleText': 'Chrome Policy',
-  }
-
-
-def get_policy_configuration_resources_dict():
-  """Get the resources for the chrome policy configuration component.
-
-    Returns:
-      A dict of the resources for the chrome policy configuration component.
-  """
-  return {
-    'hasAddFlow': False,
-    'titleText': 'Chrome Policy Configurations',
-    'getSettingsUrl': flask.url_for('get_settings'),
-    'editUrl': flask.url_for('edit_policy_config'),
-    'proxyValidityText': 'Enforce Proxy Server Check from Invitation Link',
-    'networkJailText': 'Enforce Network Jail Before Google Login',
-    'saveText': 'Save',
   }
 
 
@@ -93,17 +61,6 @@ def display_chrome_policy():
       enforce_network_jail=config.network_jail_until_google_auth)
 
 
-@ufo.app.route('/settings/', methods=['GET'])
-@ufo.setup_required
-def get_settings():
-  """Gets the current settings as a json object.
-
-  Returns:
-    A flask response with the json settings.
-  """
-  return flask.Response(_make_settings_json(), mimetype='application/json')
-
-
 @ufo.app.route('/chromepolicy/download/')
 @ufo.setup_required
 def download_chrome_policy():
@@ -114,29 +71,3 @@ def download_chrome_policy():
   """
   return flask.Response(_make_chrome_policy_json(),
                         mimetype='application/json')
-
-@ufo.app.route('/chromepolicy/edit', methods=['POST'])
-@ufo.setup_required
-def edit_policy_config():
-  """Receives the posted form for editing the policy config values.
-
-  The new policy config values are stored in the database.
-
-  Returns:
-    A redirect back to display chrome policy with will display the new values.
-  """
-  # TODO(eholder): Move the display of config values and the edit handlers to
-  # something more sensible once UI review tells us what that should be. I'm
-  # envisioning a settings or options page which is underneath the overall
-  # Setup link. For now, I just want these settings to be edittable somewhere.
-
-  config = ufo.get_user_config()
-
-  proxy_server_string = flask.request.form.get('enforce_proxy_server_validity')
-  network_jail_string = flask.request.form.get('enforce_network_jail')
-  config.proxy_server_validity = json.loads(proxy_server_string)
-  config.network_jail_until_google_auth = json.loads(network_jail_string)
-
-  config.save()
-
-  return flask.redirect(flask.url_for('get_settings'))

--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -53,6 +53,7 @@ def get_policy_configuration_resources_dict():
   return {
     'hasAddFlow': False,
     'titleText': 'Chrome Policy Configurations',
+    'editUrl': flask.url_for('edit_policy_config'),
   }
 
 

--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -41,6 +41,27 @@ def get_policy_resources_dict():
     'hasAddFlow': False,
     'policy_filename': 'chrome_policy.json',
     'titleText': 'Chrome Policy',
+    'policyExplanationText': ('Chrome policy is a feature of enterprise Google'
+        ' devices which can be used to securely add extra configuration to the'
+        ' uProxy frontend. If you use enterprise Google devices through Google'
+        ' Apps for Work, you can for example turn on validation for invitation'
+        ' links to ensure you are proxying through an endpoint controlled by '
+        'the management console.'),
+    'policyEditText': ('You can adjust the values below in the Management '
+        'Server Settings section and save to update the managed policy json.'
+        'Once you are ready, you can click the download link to get your json '
+        'policy file generated automatically.'),
+    'adminConsoleText': 'Google Admin Console',
+    'policyUploadText': ('To push your managed policy out to your devices, '
+        'visit Google Admin Console at the link above and navigate to the '
+        'uProxy Chrome App/Extension under Device Management -> Chrome '
+        'Management -> App Management. For the App and Extension, select the '
+        'entry listed, then click User settings. From the list of Orgs, choose'
+        ' which you want the policy to apply to, then enable Force '
+        'Installation and select Upload Configuration File. Choose the json '
+        'file you just downloaded. You may have to click override to edit '
+        'Force Installation or Configure\'s values. Finally, click Save.'),
+    'downloadText': 'Download',
   }
 
 

--- a/ufo/handlers/chrome_policy_test.py
+++ b/ufo/handlers/chrome_policy_test.py
@@ -47,34 +47,5 @@ class ChromePolicyTest(base_test.BaseTest):
     self.assertIn('enforce_proxy_server_validity', json_data)
     self.assertNotIn('enforce_network_jail', json_data)
 
-  def testGetSettings(self):
-    """Test the get settings handler downloads json."""
-    resp = self.client.get(flask.url_for('get_settings'))
-
-    json_data = json.loads(resp.data)
-    self.assertNotIn('proxy_server_keys', json_data)
-    self.assertIn('enforce_proxy_server_validity', json_data)
-    self.assertIn('enforce_network_jail', json_data)
-
-  def testEditValuesForPolicyConfig(self):
-    """Test posting with modified policy config values updates in the db."""
-    config = ufo.get_user_config()
-    initial_proxy_server_config = config.proxy_server_validity
-    initial_network_jail_config = config.network_jail_until_google_auth
-    data_to_post = {
-        'enforce_proxy_server_validity': json.dumps(not initial_proxy_server_config),
-        'enforce_network_jail': json.dumps(not initial_network_jail_config),
-    }
-
-    resp = self.client.post(flask.url_for('edit_policy_config'),
-                            data=data_to_post, follow_redirects=False)
-
-    updated_config = ufo.get_user_config()
-    self.assertEqual(not initial_proxy_server_config,
-                     updated_config.proxy_server_validity)
-    self.assertEqual(not initial_network_jail_config,
-                     updated_config.network_jail_until_google_auth)
-    self.assert_redirects(resp, flask.url_for('get_settings'))
-
 if __name__ == '__main__':
   unittest.main()

--- a/ufo/handlers/chrome_policy_test.py
+++ b/ufo/handlers/chrome_policy_test.py
@@ -47,6 +47,15 @@ class ChromePolicyTest(base_test.BaseTest):
     self.assertIn('enforce_proxy_server_validity', json_data)
     self.assertNotIn('enforce_network_jail', json_data)
 
+  def testGetSettings(self):
+    """Test the get settings handler downloads json."""
+    resp = self.client.get(flask.url_for('get_settings'))
+
+    json_data = json.loads(resp.data)
+    self.assertNotIn('proxy_server_keys', json_data)
+    self.assertIn('enforce_proxy_server_validity', json_data)
+    self.assertIn('enforce_network_jail', json_data)
+
   def testEditValuesForPolicyConfig(self):
     """Test posting with modified policy config values updates in the db."""
     config = ufo.get_user_config()
@@ -65,7 +74,7 @@ class ChromePolicyTest(base_test.BaseTest):
                      updated_config.proxy_server_validity)
     self.assertEqual(not initial_network_jail_config,
                      updated_config.network_jail_until_google_auth)
-    self.assert_redirects(resp, flask.url_for('display_chrome_policy'))
+    self.assert_redirects(resp, flask.url_for('get_settings'))
 
 if __name__ == '__main__':
   unittest.main()

--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -31,4 +31,5 @@ from ufo.handlers import chrome_policy
 from ufo.handlers import proxy_server
 from ufo.handlers import setup
 from ufo.handlers import search
+from ufo.handlers import settings
 from ufo.handlers import user

--- a/ufo/handlers/settings.py
+++ b/ufo/handlers/settings.py
@@ -1,0 +1,79 @@
+"""The module for generating and outputing management server settings."""
+
+import json
+
+import flask
+
+import ufo
+from ufo.database import models
+
+
+def _make_settings_json():
+  """Generates the json string of all settings based on values in the db.
+
+  Returns:
+    A json string of current server settings.
+  """
+  config = ufo.get_user_config()
+
+  settings_dictionary = {
+      "enforce_network_jail": config.network_jail_until_google_auth,
+      "enforce_proxy_server_validity": config.proxy_server_validity,
+  }
+
+  return json.dumps(settings_dictionary)
+
+
+def get_settings_resources_dict():
+  """Get the resources for the settings configuration component.
+
+    Returns:
+      A dict of the resources for the settings configuration component.
+  """
+  return {
+    'hasAddFlow': False,
+    'titleText': 'Management Server Settings',
+    'getSettingsUrl': flask.url_for('get_settings'),
+    'editUrl': flask.url_for('edit_settings'),
+    'proxyValidityText': 'Enforce Proxy Server Check from Invitation Link',
+    'networkJailText': 'Enforce Network Jail Before Google Login',
+    'saveText': 'Save',
+  }
+
+
+@ufo.app.route('/settings/', methods=['GET'])
+@ufo.setup_required
+def get_settings():
+  """Gets the current settings as a json object.
+
+  Returns:
+    A flask response with the json settings.
+  """
+  return flask.Response(_make_settings_json(), mimetype='application/json')
+
+
+@ufo.app.route('/chromepolicy/edit', methods=['POST'])
+@ufo.setup_required
+def edit_settings():
+  """Receives the posted form for editing the policy config values.
+
+  The new policy config values are stored in the database.
+
+  Returns:
+    A redirect back to display chrome policy with will display the new values.
+  """
+  # TODO(eholder): Move the display of config values and the edit handlers to
+  # something more sensible once UI review tells us what that should be. I'm
+  # envisioning a settings or options page which is underneath the overall
+  # Setup link. For now, I just want these settings to be edittable somewhere.
+
+  config = ufo.get_user_config()
+
+  proxy_server_string = flask.request.form.get('enforce_proxy_server_validity')
+  network_jail_string = flask.request.form.get('enforce_network_jail')
+  config.proxy_server_validity = json.loads(proxy_server_string)
+  config.network_jail_until_google_auth = json.loads(network_jail_string)
+
+  config.save()
+
+  return flask.redirect(flask.url_for('get_settings'))

--- a/ufo/handlers/settings_test.py
+++ b/ufo/handlers/settings_test.py
@@ -1,0 +1,51 @@
+"""Test settings module functionality."""
+
+import json
+import unittest
+
+import flask
+import mock
+
+import ufo
+from ufo import base_test
+
+
+class SettingsTest(base_test.BaseTest):
+  """Test settings functionality."""
+
+  def setUp(self):
+    """Setup test app on which to call handlers and db to query."""
+    super(SettingsTest, self).setUp()
+    super(SettingsTest, self).setup_config()
+
+  def testGetSettings(self):
+    """Test the get settings handler downloads json."""
+    resp = self.client.get(flask.url_for('get_settings'))
+
+    json_data = json.loads(resp.data)
+    self.assertNotIn('proxy_server_keys', json_data)
+    self.assertIn('enforce_proxy_server_validity', json_data)
+    self.assertIn('enforce_network_jail', json_data)
+
+  def testEditSettings(self):
+    """Test posting with modified settings updates in the db."""
+    config = ufo.get_user_config()
+    initial_proxy_server_config = config.proxy_server_validity
+    initial_network_jail_config = config.network_jail_until_google_auth
+    data_to_post = {
+        'enforce_proxy_server_validity': json.dumps(not initial_proxy_server_config),
+        'enforce_network_jail': json.dumps(not initial_network_jail_config),
+    }
+
+    resp = self.client.post(flask.url_for('edit_settings'),
+                            data=data_to_post, follow_redirects=False)
+
+    updated_config = ufo.get_user_config()
+    self.assertEqual(not initial_proxy_server_config,
+                     updated_config.proxy_server_validity)
+    self.assertEqual(not initial_network_jail_config,
+                     updated_config.network_jail_until_google_auth)
+    self.assert_redirects(resp, flask.url_for('get_settings'))
+
+if __name__ == '__main__':
+  unittest.main()

--- a/ufo/handlers/setup.py
+++ b/ufo/handlers/setup.py
@@ -9,6 +9,7 @@ import ufo
 from ufo.handlers import chrome_policy
 from ufo.handlers import user
 from ufo.handlers import proxy_server
+from ufo.handlers import settings
 from ufo.services import oauth
 
 
@@ -51,13 +52,12 @@ def setup():
     oauth_resources_dict = _get_oauth_configration_resources_dict(config,
                                                                   oauth_url)
     policy_resources_dict = chrome_policy.get_policy_resources_dict()
-    policy_config_resources_dict = (
-        chrome_policy.get_policy_configuration_resources_dict())
+    settings_resources_dict = settings.get_settings_resources_dict()
 
     return flask.render_template(
         'setup.html',
         oauth_url=oauth_url,
-        policy_config_resources=json.dumps(policy_config_resources_dict),
+        settings_resources=json.dumps(settings_resources_dict),
         policy_resources=json.dumps(policy_resources_dict),
         proxy_server_resources=json.dumps(proxy_server_resources_dict),
         oauth_resources=json.dumps(oauth_resources_dict),

--- a/ufo/handlers/setup_test.py
+++ b/ufo/handlers/setup_test.py
@@ -39,7 +39,9 @@ class SetupTest(base_test.BaseTest):
     args, kwargs = mock_render_template.call_args
     self.assertEquals('setup.html', args[0])
     self.assertIsNotNone(kwargs['oauth_resources'])
+    self.assertIsNotNone(kwargs['settings_resources'])
     self.assertIsNotNone(kwargs['policy_resources'])
+    self.assertIsNotNone(kwargs['proxy_server_resources'])
     self.assertIsNotNone(kwargs['oauth_url'])
     self.assertIsNotNone(kwargs['user_resources'])
 

--- a/ufo/static/chromePolicy.html
+++ b/ufo/static/chromePolicy.html
@@ -13,34 +13,21 @@
   <template>
     <paper-listbox id="chrome-policy">
       <paper-item><p>
-        Chrome policy is a feature of enterprise Google devices which can
-        be used to securely add extra configuration to the uProxy frontend.
-        If you use enterprise Google devices through Google Apps for Work,
-        you can for example turn on validation for invitation links to
-        ensure you are proxying through an endpoint controlled by the
-        management console.
+        {{resources.policyExplanationText}}
       </p></paper-item>
       <paper-item><p>
-        You can adjust the values below and save to see the managed policy
-        json update. Once you are ready, you can copy and paste the managed
-        policy json below into its own file or click the download link to
-        have one generated automatically.
+        {{resources.policyEditText}}
+      </p></paper-item>
+      <paper-item>
+      <a href="https://admin.google.com/AdminHome" class="anchor-no-button">{{resources.adminConsoleText}}</a>
       </p></paper-item>
       <paper-item><p>
-        To push your managed policy out to your devices, visit
-        <a href="https://admin.google.com/AdminHome" class="anchor-no-button">Google Admin Console</a>
-         and navigate to the uProxy Chrome App/Extension under Device
-        Management -> Chrome Management -> App Management. For the App and Extension, select the entry listed, then click User settings. From
-        the list of Orgs, choose which you want the policy to apply to, then
-        enable Force Installation and select Upload Configuration File.
-        Choose the json file you just created/downloaded. You may have to
-        click override to edit Force Installation or Configure's values.
-        Finally, click Save.
+        {{resources.policyUploadText}}
       </p></paper-item>
       <div class="buttons">
         <paper-item>
           <a href="{{resources.download_chrome_policy}}" download="{{resources.policy_filename}}">
-            <paper-button class="anchor-button"><iron-icon icon="file-download"></iron-icon> Download Policy</paper-button>
+            <paper-button class="anchor-button"><iron-icon icon="file-download"></iron-icon> {{resources.downloadText}}</paper-button>
           </a>
         </paper-item>
       </div>

--- a/ufo/static/chromePolicyConfiguration.html
+++ b/ufo/static/chromePolicyConfiguration.html
@@ -1,4 +1,7 @@
+<link rel="import" href="bower_components/iron-ajax/iron-ajax.html" />
+<link rel="import" href="bower_components/iron-form/iron-form.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
+<link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
 
 <dom-module id="chrome-policy-configuration">
   <style is="custom-style">
@@ -9,15 +12,26 @@
     }
   </style>
   <template>
-    <form id="policy-config-form" method="post" action="{{resources.editUrl}}">
-      <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="Enforce Proxy Server Check from Invitation Link" {% if enforce_proxy_server_validity %}checked{% endif %}></ufo-toggle-input>
+    <template is="dom-if" if="{{loading}}">
+      <paper-spinner id="spinner" active$={{loading}}></paper-spinner>
+    </template>
+    <iron-ajax auto
+      url="{{resources.getSettingsUrl}}"
+      method="GET"
+      handle-as="json"
+      id="getSettingsAjax"
+      loading="{{loading}}"
+      last-response="{{ajaxResponse}}">
+    </iron-ajax>
+    <form is="iron-form" id="policy-config-form" method="post" action="{{resources.editUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseConfigResponse">
+      <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="{{resources.proxyValidityText}}" checked$={{ajaxResponse.enforce_proxy_server_validity}}></ufo-toggle-input>
       <br>
-      <ufo-toggle-input input-name="enforce_network_jail" button-text="Enforce Network Jail Before Google Login" {% if enforce_network_jail %}checked{% endif %}></ufo-toggle-input>
+      <ufo-toggle-input input-name="enforce_network_jail" button-text="{{resources.networkJailText}}" checked$={{ajaxResponse.enforce_network_jail}}></ufo-toggle-input>
       <br>
       <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
       <div class="buttons">
         <paper-button class="anchor-button" onclick="submitByFormId('policy-config-form')" type="submit">
-          Save
+          {{resources.saveText}}
         </paper-button>
       </div>
     </form>
@@ -29,9 +43,25 @@
         resources: {
           type: Object,
         },
+        loading: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
+        ajaxResponse: {
+          type: Object,
+          notify: true,
+        },
+      },
+      enableSpinner: function() {
+        this.set('loading', true);
       },
       getXsrfToken: function() {
         return document.getElementById('globalXsrf').value;
+      },
+      parseConfigResponse: function(e, details) {
+        this.set('ajaxResponse', details.xhr.response);
+        this.set('loading', false);
       },
     });
   </script>

--- a/ufo/static/chromePolicyConfiguration.html
+++ b/ufo/static/chromePolicyConfiguration.html
@@ -9,12 +9,12 @@
     }
   </style>
   <template>
-    <form id="policy-config-form" method="post" action="{{ url_for('edit_policy_config') }}">
+    <form id="policy-config-form" method="post" action="{{resources.editUrl}}">
       <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="Enforce Proxy Server Check from Invitation Link" {% if enforce_proxy_server_validity %}checked{% endif %}></ufo-toggle-input>
       <br>
       <ufo-toggle-input input-name="enforce_network_jail" button-text="Enforce Network Jail Before Google Login" {% if enforce_network_jail %}checked{% endif %}></ufo-toggle-input>
       <br>
-      <input type="hidden" name="_xsrf_token" value="{{ xsrf_token() }}">
+      <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
       <div class="buttons">
         <paper-button class="anchor-button" onclick="submitByFormId('policy-config-form')" type="submit">
           Save

--- a/ufo/static/settingsConfiguration.html
+++ b/ufo/static/settingsConfiguration.html
@@ -3,7 +3,7 @@
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
 
-<dom-module id="chrome-policy-configuration">
+<dom-module id="settings-configuration">
   <style is="custom-style">
     #policy-config-form {
       margin-left: 40px;
@@ -38,7 +38,7 @@
   </template>
   <script>
     Polymer({
-      is: 'chrome-policy-configuration',
+      is: 'settings-configuration',
       properties: {
         resources: {
           type: Object,

--- a/ufo/static/toggleInput.html
+++ b/ufo/static/toggleInput.html
@@ -2,10 +2,10 @@
 
 <dom-module id="ufo-toggle-input">
     <template>
-        <paper-toggle-button checked$="[[checked]]">
+        <paper-toggle-button checked$={{checked}}>
           {{buttonText}}
-          <input type="hidden" name="{{inputName}}" value="[[checked]]">
         </paper-toggle-button>
+        <input type="hidden" id="hiddenToggle" name="{{inputName}}" value="{{checked}}">
     </template>
 
     <script src="toggleInput.js"></script>

--- a/ufo/static/toggleInput.js
+++ b/ufo/static/toggleInput.js
@@ -17,7 +17,7 @@ Polymer({
   },
   flipHiddenInput: function(e) {
     var toggleElem = event.path[0];
-    var hiddenInput = toggleElem.querySelector('input');
+    var hiddenInput = this.$.hiddenToggle;
     hiddenInput.value = toggleElem.checked;
   }
 });

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -1,15 +1,12 @@
 {% extends "base.html" %}
 {% block title %}Setup{% endblock %}
 {% block body %}
-
   <paper-display-template resources="{{user_resources}}">
     <form-container-with-left-icon resources="{{user_resources}}">
       <user-add-tabs resources="{{user_resources}}">
       </user-add-tabs>
     </form-container-with-left-icon>
   </paper-display-template>
-
-  <br>
 
   <paper-display-template resources="{{proxy_server_resources}}">
     <form-container-with-left-icon resources="{{proxy_server_resources}}">
@@ -18,8 +15,6 @@
     </form-container-with-left-icon>
   </paper-display-template>
 
-  <br>
-
   <paper-display-template resources="{{oauth_resources}}">
     <header-container resources="{{oauth_resources}}">
       <oauth-configuration resources="{{oauth_resources}}">
@@ -27,16 +22,12 @@
     </header-container>
   </paper-display-template>
 
-  <br>
-
   <paper-display-template resources="{{policy_resources}}">
     <header-container resources="{{policy_resources}}">
       <chrome-policy resources="{{policy_resources}}">
       </chrome-policy>
     </header-container>
   </paper-display-template>
-
-  <br>
 
   <paper-display-template resources="{{policy_config_resources}}">
     <header-container resources="{{policy_config_resources}}">

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -29,10 +29,10 @@
     </header-container>
   </paper-display-template>
 
-  <paper-display-template resources="{{policy_config_resources}}">
-    <header-container resources="{{policy_config_resources}}">
-      <chrome-policy-configuration resources="{{policy_config_resources}}">
-      </chrome-policy-configuration>
+  <paper-display-template resources="{{settings_resources}}">
+    <header-container resources="{{settings_resources}}">
+      <settings-configuration resources="{{settings_resources}}">
+      </settings-configuration>
     </header-container>
   </paper-display-template>
 


### PR DESCRIPTION
The existing Chrome Policy Config element is still based on the old site, where everything was mostly using Jinja. I need to pull the server side references out, update the client to use AJAX, and make sure there is no redirect on response. I'll follow up with this later, but just starting the PR now for tracking.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/66)

<!-- Reviewable:end -->
