### PR TITLE
Pull Text from the OAuth Form Out of HTML and Into JSON

### DIFF
--- a/ufo/handlers/setup.py
+++ b/ufo/handlers/setup.py
@@ -32,6 +32,34 @@ def _get_oauth_configration_resources_dict(config, oauth_url):
     'oauth_url': oauth_url,
     'setup_url': flask.url_for('setup'),
     'titleText': 'Oauth Configuration',
+    'welcomeText': ('Hey there! Welcome to the uProxy for Organizations '
+        'management server! To start, we want to get a bit of information from'
+        ' you to get everything set up.'),
+    'googleDomainPromptText': ('First of all, if you are planning on using '
+        'this application with a Google apps domain, we\'re going to need to '
+        'get permission from you to access that. This will be used to keep '
+        'the list of users in your domain in sync with who is allowed to '
+        'access the uProxy servers. The credentials you authorize will be '
+        'shared by any administrators who log into this server. If you do not '
+        'plan on using a Google apps domain with this product, you can just go'
+        ' straight to adding users.'),
+    'successSetupText': ('You have already successfully configured this '
+        'deployment! If you want to change the settings, you may do so below. '
+        'Please note: submitting the form even without filling in any '
+        'parameters will cause the previous saved configuration to be lost.'),
+    'domainConfiguredText': ('This site is set up to work with the following '
+        'domain. If that is not correct, please update the configuration.'),
+    'noDomainConfiguredText': ('This site is not set up to use any Google apps'
+        ' domain name. All users will need to be manually input.'),
+    'betaWarningText': ('Please keep in mind that this is a much simpler '
+        'version than what you would actually expect to see in a finished '
+        'version of the site. Noteably, this page should include something '
+        'about authenticating yourself in the future (and actually include a '
+        'way to skip).'),
+    'connectYourDomainButtonText': 'Connect to Your Domain',
+    'pasteTheCodeText': ('Once you finish authorizing access, please paste the'
+        ' code you receive in the box below.'),
+    'submitButtonText': 'Submit',
   }
 
 

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -24,64 +24,45 @@
   </style>
   <template>
     <!-- TODO: Make a clear way to say you do not want to use Google apps. -->
-    <!-- TODO: Extract these strings so they can be i18n. -->
       <template is="dom-if" if="{{!resources.config.is_configured}}">
         <p>
-          Hey there!  Welcome to the uProxy for Organizations management server!
-          To start, we want to get a bit of information from you to get everything
-          set up.
+          {{resources.welcomeText}}
         </p>
         <p>
-          First of all, if you are planning on using this application with a Google
-          apps domain, we're going to need to get permission from you to access
-          that.  This will be used to keep the list of users in your domain in sync
-          with who is allowed to access the uProxy servers.  The credentials you
-          authorize will be shared by any administrators who log into this server.
-          If you do not plan on using a Google apps domain with this product, you
-          can just go straight to adding users.
+          {{resources.googleDomainPromptText}}
         </p>
       </template>
 
       <template is="dom-if" if="{{resources.config.is_configured}}">
         <p>
-          You have already successfully configured this deployment!  If you want to
-          change the settings, you may do so below.  Please note: submitting the
-          form even without filling in any parameters will cause the previous saved
-          configuration to be lost.
+          {{resources.successSetupText}}
         </p>
-  
+
         <template is="dom-if" if="{{isDomainConfigured(resources.config)}}">
           <p>
-            This site is set up to work with the
-            <strong>{{resources.config.domain}}</strong> domain.  If that is not correct,
-            please update the configuration.
+            {{resources.domainConfiguredText}} <strong>{{resources.config.domain}}</strong>
           </p>
         </template>
-  
+
         <template is="dom-if" if="{{!isDomainConfigured(resources.config)}}">
           <p>
-            This site is not set up to use any Google apps domain name, all users
-            will need to be manually input.
+            {{resources.noDomainConfiguredText}}
           </p>
         </template>
       </template>
 
         <p>
-          Please keep in mind that this is a much simpler version than what you
-          would actually expect to see in a finished version of the site.
-          Noteably, this page should include something about authenticating
-          yourself in the future (and actually include a way to skip)
+          {{resources.betaWarningText}}
         </p>
 
         <p>
-          <a class="anchor-no-button" href="{{resources.oauth_url}}" target="_blank">Connect to your domain</a>
+          <a class="anchor-no-button" href="{{resources.oauth_url}}" target="_blank">{{resources.connectYourDomainButtonText}}</a>
         </p>
 
          <p>
-           Once you finish authorizing access, please paste the code you receive in
-           the box below.
+           {{resources.pasteTheCodeText}}
          </p>
-  
+
       <!-- TODO make this form be more useful -->
       <form id="oauth-configuration-form" method="post" action="{{resources.setup_url}}">
         <paper-input label="Domain" name="domain"></paper-input>
@@ -89,7 +70,7 @@
         <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
         <div class="buttons">
           <paper-button onclick="submitByFormId('oauth-configuration-form')" class="form-submit-button anchor-button" type="submit">
-            Submit
+            {{resources.submitButtonText}}
           </paper-button>
         </div>
       </form>
@@ -107,7 +88,7 @@
         return document.getElementById('globalXsrf').value;
       },
       isDomainConfigured: function(config) {
-        return config.domain && config.credentials; 
+        return config.domain && config.credentials;
       },
     });
   </script>


### PR DESCRIPTION
Refactoring the text on the OAuth form to be specified from the server via JSON, rather than hardcoded into the html page. This will help out for i18n later. I was doing this in another PR and decided to move this out since it wasn't really related.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/69)

<!-- Reviewable:end -->
