### PR TITLE
Proper overlap with page header.

### DIFF
--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -47,6 +47,7 @@ paper-scroll-header-panel {
 
 paper-material {
   background-color: #ffffff;
+  top: -75px;  /* Make the components or cards overlap with the header. */
 }
 
 paper-material:not(.dropdown-content), #jigsaw-logo-holder {

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -47,7 +47,7 @@ paper-scroll-header-panel {
 
 paper-material {
   background-color: #ffffff;
-  top: -75px;  /* Make the components or cards overlap with the header. */
+  top: -75px;  /* Make the components or cards overlap with the page header. */
 }
 
 paper-material:not(.dropdown-content), #jigsaw-logo-holder {

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -28,46 +28,42 @@
   }
 </style>
 <body class="fullbleed layout vertical">
-    <div>
-
-  <paper-scroll-header-panel>
-    <paper-toolbar class="tall" id="main-toolbar">
-      <div class="middle horizontal layout center flex">
-        <div class="flex">
-          <a href="{{ url_for('new_landing') }}">
-            <img src="{{ url_for('static', filename='img/ufo-logo.svg') }}" alt="uProxy Logo" height="80" width="80">
-          </a>
+  <div>  <!-- Prevent the main-holder from pushing into the header. -->
+    <paper-scroll-header-panel>
+      <paper-toolbar class="tall" id="main-toolbar">
+        <div class="middle horizontal layout center flex">
+          <div class="flex">
+            <a href="{{ url_for('new_landing') }}">
+              <img src="{{ url_for('static', filename='img/ufo-logo.svg') }}" alt="uProxy Logo" height="80" width="80">
+            </a>
+          </div>
+          <div class="flex"></div>
+          <div class="vertical layout flex-4">
+            <div class="verticalSpacer"><p></div>
+            <ufo-search-bar class="flex" user-resources="{{user_resources}}" proxy-server-resources="{{proxy_server_resources}}">
+            </ufo-search-bar>
+            <div class="verticalSpacer"></div>
+          </div>
+          <div class="flex"></div>
+          <paper-dropdown-menu label="foo" id="username-and-menu" class="custom-dropdown flex">
+            <paper-listbox class="dropdown-content">
+              <paper-icon-item class="dropdown-button">
+                <iron-icon class="dropdown-icon" src="{{url_for('static', filename='img/add-users.svg')}}" item-icon></iron-icon>
+                Add an Admin
+              </paper-icon-item>
+              <paper-icon-item class="dropdown-button">
+                <iron-icon class="dropdown-icon" icon="settings" item-icon></iron-icon>
+                Settings
+              </paper-icon-item>
+              <paper-item class="dropdown-button">
+                Log Out
+              </paper-item>
+            </paper-listbox>
+          </paper-dropdown-menu>
         </div>
-        <div class="flex"></div>
-        <div class="vertical layout flex-4">
-          <div class="verticalSpacer"><p></div>
-          <ufo-search-bar class="flex" user-resources="{{user_resources}}" proxy-server-resources="{{proxy_server_resources}}">
-          </ufo-search-bar>
-          <div class="verticalSpacer"></div>
-        </div>
-        <div class="flex"></div>
-        <paper-dropdown-menu label="foo" id="username-and-menu" class="custom-dropdown flex">
-          <paper-listbox class="dropdown-content">
-            <paper-icon-item class="dropdown-button">
-              <iron-icon class="dropdown-icon" src="{{url_for('static', filename='img/add-users.svg')}}" item-icon></iron-icon>
-              Add an Admin
-            </paper-icon-item>
-            <paper-icon-item class="dropdown-button">
-              <iron-icon class="dropdown-icon" icon="settings" item-icon></iron-icon>
-              Settings
-            </paper-icon-item>
-            <paper-item class="dropdown-button">
-              Log Out
-            </paper-item>
-          </paper-listbox>
-        </paper-dropdown-menu>
-      </div>
-    </paper-toolbar>
-  </paper-scroll-header-panel>
-
-
-
-    </div>
+      </paper-toolbar>
+    </paper-scroll-header-panel>
+  </div>
   <div class="layout vertical" id="main-holder">
     {% block body %}{% endblock %}
     <br>

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -15,6 +15,10 @@
       color: white;
     };
   }
+  paper-scroll-header-panel {
+    background-color: #009788!important;
+    height: 250px;
+  }
   .dropdown-icon {
     width: 20px;
     --iron-icon-fill-color: #009788;
@@ -24,6 +28,8 @@
   }
 </style>
 <body class="fullbleed layout vertical">
+    <div>
+
   <paper-scroll-header-panel>
     <paper-toolbar class="tall" id="main-toolbar">
       <div class="middle horizontal layout center flex">
@@ -58,6 +64,10 @@
       </div>
     </paper-toolbar>
   </paper-scroll-header-panel>
+
+
+
+    </div>
   <div class="layout vertical" id="main-holder">
     {% block body %}{% endblock %}
     <br>


### PR DESCRIPTION
This PR does a few things (see screenshots below):
- Prevent the main-holder from pushing up against the page header.
- Make the background color fill out on the page header.
- Which then makes it simple for the cards or components to overlap with the page header.

![screenshot from 2016-03-16 09 46 44](https://cloud.githubusercontent.com/assets/6977544/13820956/ea415d42-eb5c-11e5-8d88-3bd259c0f208.png)

![screenshot from 2016-03-16 09 47 05](https://cloud.githubusercontent.com/assets/6977544/13820966/f2a02464-eb5c-11e5-9b3e-512e9718badb.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/70)

<!-- Reviewable:end -->
