### PR TITLE
Rename left icon container.

### DIFF
--- a/ufo/static/leftIconContainer.html
+++ b/ufo/static/leftIconContainer.html
@@ -1,4 +1,6 @@
-<dom-module id="form-container-with-left-icon">
+<link rel="import" href="bower_components/polymer/polymer.html">
+
+<dom-module id="left-icon-container">
   <style is="custom-style">
     #container {
       display: table;
@@ -46,7 +48,7 @@
   </template>
   <script>
     Polymer({
-      is: 'form-container-with-left-icon',
+      is: 'left-icon-container',
       properties: {
         resources: {
           type: Object,

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -2,17 +2,17 @@
 {% block title %}Setup{% endblock %}
 {% block body %}
   <paper-display-template resources="{{user_resources}}">
-    <form-container-with-left-icon resources="{{user_resources}}">
+    <left-icon-container resources="{{user_resources}}">
       <user-add-tabs resources="{{user_resources}}">
       </user-add-tabs>
-    </form-container-with-left-icon>
+    </left-icon-container>
   </paper-display-template>
 
   <paper-display-template resources="{{proxy_server_resources}}">
-    <form-container-with-left-icon resources="{{proxy_server_resources}}">
+    <left-icon-container resources="{{proxy_server_resources}}">
       <server-add-form resources="{{proxy_server_resources}}">
       </server-add-form>
-    </form-container-with-left-icon>
+    </left-icon-container>
   </paper-display-template>
 
   <paper-display-template resources="{{oauth_resources}}">


### PR DESCRIPTION
Changing the name here to something that's nicer, and is more consistent with the "headerContainer".

When testing this, I got the error: “Uncaught ReferenceError: Polymer is not defined” thus unable to see the left icon.  This can be fixed by importing polymer.html.  Would you know why?  This is especially odd since none of the other custom elements need this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/73)

<!-- Reviewable:end -->
