### PR TITLE
Updating Chrome Policy Format for Proxy Servers

### DIFF
--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -17,13 +17,19 @@ def _make_chrome_policy_json():
     A json string of current chrome policy.
   """
   proxy_servers = models.ProxyServer.query.all()
-  proxy_server_public_keys = [s.get_public_key_as_authorization_file_string() for s in proxy_servers]
+  proxy_server_dicts = []
+  for server in proxy_servers:
+    proxy_server_dict = {
+        'ip': server.ip_address,
+        'public_key': server.get_public_key_as_authorization_file_string(),
+    }
+    proxy_server_dicts.append(proxy_server_dict)
 
   config = ufo.get_user_config()
 
   policy_dictionary = {
-      "proxy_server_keys": proxy_server_public_keys,
-      "enforce_proxy_server_validity": config.proxy_server_validity,
+      "validProxyServers": proxy_server_dicts,
+      "enforceProxyServerValidity": config.proxy_server_validity,
   }
 
   return json.dumps(policy_dictionary)

--- a/ufo/handlers/chrome_policy_test.py
+++ b/ufo/handlers/chrome_policy_test.py
@@ -23,8 +23,8 @@ class ChromePolicyTest(base_test.BaseTest):
     resp = self.client.get(flask.url_for('download_chrome_policy'))
 
     json_data = json.loads(resp.data)
-    self.assertIn('proxy_server_keys', json_data)
-    self.assertIn('enforce_proxy_server_validity', json_data)
+    self.assertIn('validProxyServers', json_data)
+    self.assertIn('enforceProxyServerValidity', json_data)
     self.assertNotIn('enforce_network_jail', json_data)
 
 if __name__ == '__main__':

--- a/ufo/handlers/settings_test.py
+++ b/ufo/handlers/settings_test.py
@@ -23,7 +23,7 @@ class SettingsTest(base_test.BaseTest):
     resp = self.client.get(flask.url_for('get_settings'))
 
     json_data = json.loads(resp.data)
-    self.assertNotIn('proxy_server_keys', json_data)
+    self.assertNotIn('validProxyServers', json_data)
     self.assertIn('enforce_proxy_server_validity', json_data)
     self.assertIn('enforce_network_jail', json_data)
 


### PR DESCRIPTION
Updating Chrome Policy to match uProxy's naming convention for settings as well as include proxy servers as dictionary objects with ip address and public key as properties (rather than just the public key).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/75)

<!-- Reviewable:end -->
