### PR TITLE
Fix Type Error on Setup Page from Query Selector

### DIFF
--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -56,9 +56,12 @@
         <paper-button on-tap="resetForms" class="anchor-button"><strong>{{resources.lookAgainText}}</strong></paper-button>
         <script>
         var modal = document.getElementById('userModal');
-        var scrollables = modal.getElementsByTagName('paper-dialog-scrollable');
-        for (var i in scrollables) {
-          scrollables[i].dialogElement = modal;
+        if (modal) {
+          var scrollables = modal.getElementsByTagName(
+            'paper-dialog-scrollable');
+          for (var i in scrollables) {
+            scrollables[i].dialogElement = modal;
+          }
         }
         </script>
       </template>


### PR DESCRIPTION
Fixing the error Henry ran into with the add user flow on the setup page. It was being caused by the user add form attempting to set the dialog element on a modal when the form is being used outside a modal. This happens on the setup page, so we simply check if the modal is found and don't proceed if not. On the landing page, the form is within a dialog, so this works as intended.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/77)

<!-- Reviewable:end -->
