### PR TITLE
Make sure unique proxy servers can not be added more than once.

### DIFF
--- a/ufo/database/models.py
+++ b/ufo/database/models.py
@@ -236,7 +236,7 @@ class ProxyServer(Model):
 
   id = ufo.db.Column(ufo.db.Integer, primary_key=True)
 
-  ip_address = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
+  ip_address = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH), unique=True)
   name = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))
   ssh_private_key = ufo.db.Column(ufo.db.LargeBinary())
   ssh_private_key_type = ufo.db.Column(ufo.db.String(LONG_STRING_LENGTH))

--- a/ufo/handlers/proxy_server_test.py
+++ b/ufo/handlers/proxy_server_test.py
@@ -92,6 +92,32 @@ class ProxyServerTest(base_test.BaseTest):
     self.assertEqual(getBinaryPublicKey(fake_server['key']),
                      proxy_server_in_db.host_public_key)
 
+  def testProxyServerCanNotBeAddedMoreThanOnce(self):
+    """Test that the proxy server can not be added more than."""
+    fake_server = FAKE_PROXY_SERVER_DATA[0]
+    form_data = self._GetProxyServerFormData()
+    response = self.client.post(
+        flask.url_for('proxyserver_add'),
+        data=form_data,
+        follow_redirects=False)
+    response = self.client.post(
+        flask.url_for('proxyserver_add'),
+        data=form_data,
+        follow_redirects=False)
+
+    query = models.ProxyServer.query
+    query.filter_by(ip_address=fake_server['ip_address'])
+    
+    self.assertEqual(1, query.count())
+    proxy_server_in_db = query.one_or_none()
+    self.assertIsNotNone(proxy_server_in_db)
+    self.assertEqual(fake_server['name'],
+                     proxy_server_in_db.name)
+    self.assertEqual(fake_server['key'].exportKey('DER'),
+                     proxy_server_in_db.ssh_private_key)
+    self.assertEqual(getBinaryPublicKey(fake_server['key']),
+                     proxy_server_in_db.host_public_key)
+
   def testAddingProxyServerRedirectsToList(self):
     """Tests the redirect after adding a proxy server.
 

--- a/ufo/handlers/proxy_server_test.py
+++ b/ufo/handlers/proxy_server_test.py
@@ -107,7 +107,7 @@ class ProxyServerTest(base_test.BaseTest):
 
     query = models.ProxyServer.query
     query.filter_by(ip_address=fake_server['ip_address'])
-    
+
     self.assertEqual(1, query.count())
     proxy_server_in_db = query.one_or_none()
     self.assertIsNotNone(proxy_server_in_db)

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -253,7 +253,7 @@ def add_user():
     # Save on each user so that we can let the database check if the
     # uniqueness constraint is fulfilled.  i.e don't batch this because
     # if one user is added more than once then the whole session will fail.
-    db_user.save(commit=True)
+    db_user.save()
 
   return user_list()
 

--- a/ufo/handlers/user_test.py
+++ b/ufo/handlers/user_test.py
@@ -231,7 +231,7 @@ class UserTest(base_test.BaseTest):
     self.assertEqual(response.data, self.client.get(flask.url_for('user_list')).data)
 
   def testUserCanNotBeAddedMoreThanOnce(self):
-    """Test that user can not added more than once."""
+    """Test that user can not be added more than once."""
     response = self.create_user_with_manual_post()
     response = self.create_user_with_manual_post()
 


### PR DESCRIPTION
This is a follow-up from the previous code review, where we also need to make sure unique proxy servers can not be added more than once.
- added a uniqueness constraint on the ip address
- added a unit test
- a couple of super minor clean-ups

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/78)

<!-- Reviewable:end -->
