### PR TITLE
Hook in the new error notification for users and admins.

### DIFF
--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -179,7 +179,6 @@ def add_user():
     except custom_exceptions.UnableToSaveToDB as e:
       flask.abort(e.code, e.message)
 
-
   return user_list()
 
 @ufo.app.route('/user/delete', methods=['POST'])

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -191,6 +191,9 @@
           notify: true,
         },
       },
+      listeners: {
+        'iron-form-error': 'handleFormError',
+      },
       getXsrfToken: function() {
         return document.getElementById('globalXsrf').value;
       },
@@ -214,25 +217,34 @@
       openAddAdminDialog: function() {
         this.$.addAdminDialog.open();
       },
-      closeAddAdminDialog: function() {
-        this.$.addAdminDialog.close();
-      },
       openRemoveAdminDialog: function() {
         this.$.removeAdminDialog.open();
       },
-      closeRemoveAdminDialog: function() {
-        this.$.removeAdminDialog.close();
+      closeAdminDialog: function() {
+        this.set('loading', false);  // Disables the spinner.
+        var addAdminDialog = document.getElementById('addAdminDialog');
+        if (addAdminDialog) {
+          this.$.addAdminDialog.close();
+        } else {
+          this.$.removeAdminDialog.close();
+        }
+      },
+      handleFormError: function(event, detail) {
+        var errorDetail = {'detail': detail.request.xhr.response};
+        var errorEvent = new CustomEvent('ApplicationError', errorDetail);
+        document.getElementById('error-notification').dispatchEvent(errorEvent);
+        this.closeAdminDialog();
       },
       flipToDropdownFlowFromAddAdmin: function(e, details) {
         this.openMenu();
-        this.closeAddAdminDialog();
+        this.closeAdminDialog();
         this.resetAddAdminForm();
         this.set('showResponseStatus', false);
         this.set('responseStatus', '');
       },
       flipToDropdownFlowFromRemoveAdmin: function(e, details) {
         this.openMenu();
-        this.closeRemoveAdminDialog();
+        this.closeAdminDialog();
         this.resetRemoveAdminForm();
       },
       enableSpinner: function() {

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -110,6 +110,9 @@
           notify: true,
         },
       },
+      listeners: {
+        'iron-form-error': 'handleFormError',
+      },
       enableSpinner: function() {
         this.set('isSpinnerOn', true);
       },
@@ -125,14 +128,23 @@
         this.set('showInputFields', false);
         this.set('isSpinnerOn', false);
       },
-      parsePostResponse: function(e, details) {
-        this.sendUsersJsonToList(details.xhr.response);
+      closeModal: function() {
         this.set('isSpinnerOn', false);
-        this.resetForms();
         var userModal = document.getElementById('userModal');
         if (userModal) {
           userModal.close();
         }
+      },
+      parsePostResponse: function(e, details) {
+        this.sendUsersJsonToList(details.xhr.response);
+        this.resetForms();
+        this.closeModal();
+      },
+      handleFormError: function(event, detail) {
+        var errorDetail = {'detail': detail.request.xhr.response};
+        var errorEvent = new CustomEvent('ApplicationError', errorDetail);
+        document.getElementById('error-notification').dispatchEvent(errorEvent);
+        this.closeModal();
       },
       resetForms: function() {
         this.set('showInputFields', true);

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -92,6 +92,9 @@
           notify: true,
         },
       },
+      listeners: {
+        'iron-form-error': 'handleFormError',
+      },
       enableSpinner: function() {
         this.set('isSpinnerOn', true);
       },
@@ -108,14 +111,25 @@
         this.makeManualInputsJsonArray();
         this.querySelector('#manualAdd').submit();
       },
-      parsePostResponse: function(e, detail) {
-        this.sendUsersJsonToList(detail.xhr.response);
+
+
+      closeModal: function() {
         this.set('isSpinnerOn', false);
-        this.resetForm();
         var userModal = document.getElementById('userModal');
         if (userModal) {
           userModal.close();
         }
+      },
+      parsePostResponse: function(e, detail) {
+        this.sendUsersJsonToList(detail.xhr.response);
+        this.resetForm();
+        this.closeModal();
+      },
+      handleFormError: function(event, detail) {
+        var errorDetail = {'detail': detail.request.xhr.response};
+        var errorEvent = new CustomEvent('ApplicationError', errorDetail);
+        document.getElementById('error-notification').dispatchEvent(errorEvent);
+        this.closeModal();
       },
       resetForm: function() {
         var formElem = document.getElementById('manualAdd');


### PR DESCRIPTION
- This PR hooks in the new error notification when trying to add users or admins more than once.
- I attempted to hook this in for other exceptions (SetupNeeded, NotLoggedIn), but I can't find an easy way register an error listener/handler on the frontend for these (like I can for a form-error or ajax-error).  So, they will continue to route to the error page.  (Is there any other ideas?  This is one thing I think where angular is superior to polymer.)
- Will follow-up to add webdriver tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/85)

<!-- Reviewable:end -->
