### PR TITLE
Webdriver test for the new error notification UI.

### DIFF
--- a/tests/ui/error_notification.py
+++ b/tests/ui/error_notification.py
@@ -28,7 +28,7 @@ class ErrorNotification(BaseDriver):
     except NoSuchElementException:
       return False
     return True
-  
+
   def is_displayed(self):
     """Whether the error notification is displayed (i.e. visible) on the page.
 

--- a/tests/ui/error_notification.py
+++ b/tests/ui/error_notification.py
@@ -1,0 +1,64 @@
+"""Module representing the error notification page object & functionalities."""
+
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from base_driver import BaseDriver
+from login_page import LoginPage
+
+
+class ErrorNotification(BaseDriver):
+  """Error notification page object and functionalities."""
+
+  ERROR_NOTIFICATION_ELEMENT = (By.ID, 'error-notification')
+  ERROR_NOTIFICATION_DIALOG = (By.ID, 'errorNotificationDialog')
+  ERROR_NOTIFICATION_CLOSE_BUTTON = (By.ID, 'errorNotificationCloseButton')
+  ERROR_MESSAGE_ELEMENT = (By.ID, 'errorMessage')
+
+
+  def is_present(self):
+    """Whether the error notification element is present on the page.
+
+    Returns: boolean, true if present, else false
+    """
+    try:
+      self.GetElement(self.ERROR_NOTIFICATION_ELEMENT)
+    except NoSuchElementException:
+      return False
+    return True
+  
+  def is_displayed(self):
+    """Whether the error notification is displayed (i.e. visible) on the page.
+
+    Returns: boolean, true if present, else false
+    """
+    error_notification_dialog = self.GetElement(self.ERROR_NOTIFICATION_DIALOG)
+    if error_notification_dialog.is_displayed():
+      return True
+    return False
+
+  def has_error_message(self, message):
+    """Whether the specified message is present in the error notification.
+
+    Returns: boolean, true if present, else false
+    """
+    is_present = EC.text_to_be_present_in_element(self.ERROR_MESSAGE_ELEMENT,
+                                                  message)
+    if is_present is False:
+      return False
+    return True
+
+  def close(self):
+    """Close the error notification, so that it's not displayed anymore.
+
+    Not catching the NoSuchElementException on purpose, so that the
+    exception will cause the test to fail.
+    """
+    self.GetElement(self.ERROR_NOTIFICATION_CLOSE_BUTTON).click()
+    # Need to wait for the button's ripple effect to complete.
+    # TODO: Move the DEFAULT_TIMEOUT out of the base_test, so that it's
+    # reusable by page objects.
+    WebDriverWait(self.driver, 30).until(
+        EC.invisibility_of_element_located((self.ERROR_NOTIFICATION_CLOSE_BUTTON)))

--- a/tests/ui/error_notification_test.py
+++ b/tests/ui/error_notification_test.py
@@ -1,0 +1,67 @@
+"""Test error notification functionalities."""
+import unittest
+
+import flask
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from base_test import BaseTest
+from error_notification import ErrorNotification
+from login_page import LoginPage
+from landing_page import LandingPage
+from ufo.services import custom_exceptions
+
+
+class ErrorNotificationTest(BaseTest):
+  """Tests for error notifications."""
+
+  def setUp(self):
+    """Setup for test methods."""
+    super(ErrorNotificationTest, self).setUp()
+    super(ErrorNotificationTest, self).setContext()
+    LoginPage(self.driver).Login(self.args.server_url, self.args.username,
+                                 self.args.password)
+
+  def tearDown(self):
+    """Teardown for test methods."""
+    self.removeTestUser(should_raise_exception=False)
+    LoginPage(self.driver).Logout(self.args.server_url)
+    super(ErrorNotificationTest, self).tearDown()
+
+  def testErrorNotificationIsWorking(self):
+    """Test the error notification is properly wired up, opened, and closed.
+
+    Not testing the actual behavior directly (e.g. the db save) as those should
+    be covered by unit tests.
+    """
+    self.driver.get(self.args.server_url + flask.url_for('landing'))
+    landing_page = LandingPage(self.driver)
+
+    # By default the error notification will be present but not displayed.
+    error_notification = ErrorNotification(self.driver)
+    self.assertTrue(error_notification.is_present())
+    self.assertFalse(error_notification.is_displayed())
+
+    # TODO: The page object model would have expected this to be:
+    # LandingPage.addTestUser()
+    self.addTestUserFromLandingPage()
+    self.addTestUserFromLandingPage()
+    
+    # Trying to add the same user twice will cause the error notification
+    # to be displayed.
+    WebDriverWait(self.driver, self.DEFAULT_TIMEOUT).until(
+        EC.visibility_of_element_located((
+            error_notification.ERROR_NOTIFICATION_DIALOG)))
+    self.assertTrue(error_notification.is_displayed())
+
+    # Check the correct error message is displayed.
+    message = custom_exceptions.UnableToSaveToDB.message
+    self.assertTrue(error_notification.has_error_message(message))
+
+    # Check we can close the error notification.
+    error_notification.close()
+    self.assertFalse(error_notification.is_displayed())
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/ui/error_notification_test.py
+++ b/tests/ui/error_notification_test.py
@@ -46,7 +46,7 @@ class ErrorNotificationTest(BaseTest):
     # LandingPage.addTestUser()
     self.addTestUserFromLandingPage()
     self.addTestUserFromLandingPage()
-    
+
     # Trying to add the same user twice will cause the error notification
     # to be displayed.
     WebDriverWait(self.driver, self.DEFAULT_TIMEOUT).until(
@@ -55,6 +55,7 @@ class ErrorNotificationTest(BaseTest):
     self.assertTrue(error_notification.is_displayed())
 
     # Check the correct error message is displayed.
+    # TODO: Make it testable for i18n.
     message = custom_exceptions.UnableToSaveToDB.message
     self.assertTrue(error_notification.has_error_message(message))
 

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -45,6 +45,7 @@ def MakeSuite(testcase_class):
 
 SUITE = unittest.TestSuite()
 SUITE.addTest(MakeSuite(AdminFlowTest))
+SUITE.addTest(MakeSuite(ErrorNotificationTest))
 SUITE.addTest(MakeSuite(LandingPageTest))
 SUITE.addTest(MakeSuite(LoginPageTest))
 SUITE.addTest(MakeSuite(SearchPageTest))

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -3,7 +3,7 @@ import argparse
 import unittest
 
 from admin_flow_test import AdminFlowTest
-from landing_page_test import ErrorNotificationPageTest
+from landing_page_test import ErrorNotificationTest
 from landing_page_test import LandingPageTest
 from login_page_test import LoginPageTest
 from search_page_test import SearchPageTest

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -3,6 +3,7 @@ import argparse
 import unittest
 
 from admin_flow_test import AdminFlowTest
+from landing_page_test import ErrorNotificationPageTest
 from landing_page_test import LandingPageTest
 from login_page_test import LoginPageTest
 from search_page_test import SearchPageTest

--- a/tests/ui/ui_test_suite.py
+++ b/tests/ui/ui_test_suite.py
@@ -3,7 +3,7 @@ import argparse
 import unittest
 
 from admin_flow_test import AdminFlowTest
-from landing_page_test import ErrorNotificationTest
+from error_notification_test import ErrorNotificationTest
 from landing_page_test import LandingPageTest
 from login_page_test import LoginPageTest
 from search_page_test import SearchPageTest

--- a/ufo/static/errorNotification.html
+++ b/ufo/static/errorNotification.html
@@ -77,7 +77,9 @@
             </div>
           </div>
           <div>
-            <paper-button class="custom" on-transitionend="closeErrorNotification">
+            <paper-button id=errorNotificationCloseButton
+                          class="custom"
+                          on-transitionend="closeErrorNotification">
               Close
             </paper-button>
           </div>


### PR DESCRIPTION
- This is a functional test to make sure the new error notification UI is properly wired up, can be opened, and then can be closed.
- Please note how the error_notification page object is structured to be self-contained, i.e. the locators and methods that acts on them are all together, rather than having them in base_test.py and layout.py.
- For another example, I encountered `self.addTestUserFromLandingPage()`
  But page object model would have expected something like `landing_page.addTestUser()`
  And also `setup_page.addTestServer()` instead.
- Hope I have used the correct common methods.  But if I missed anything, please let me know.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/87)

<!-- Reviewable:end -->
