### PR TITLE
Reverting the Changes Made to Vulcanize NPM Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ufo-management-server",
   "dependencies": {
     "bower": "^1.7.1",
-    "vulcanize": "1.14.8"
+    "vulcanize": "^1.14.8"
   },
   "scripts": {
     "postinstall": "bower install && ./vulcanize.sh travis"

--- a/vulcanize.sh
+++ b/vulcanize.sh
@@ -44,7 +44,7 @@ function runInStaticDirAndAssertCmd ()
 
 function installVulcanize ()
 {
-  runAndAssertCmd "sudo npm install -g vulcanize@1.14.8"
+  runAndAssertCmd "sudo npm install -g vulcanize"
 }
 
 function updateBowerPackages ()
@@ -117,7 +117,7 @@ if [ "$#" == 0 ] || [ ! "$1" == 'help' && ! "$1" == '--help' ]; then
   createSingleHtmlFileToVulcanize
   vulcanizeSingleFileForImports
 elif [ "$1" == 'travis' ]; then
-  runAndAssertCmd "npm install -g vulcanize@1.14.8"
+  runAndAssertCmd "npm install -g vulcanize"
   updateBowerPackages
   findHtmlFilesToVulcanize
   createSingleHtmlFileToVulcanize


### PR DESCRIPTION
The bad version, 1.14.9, was publicly rolled back so it is safe to go from head now. I'm still tracking their bug for further updates.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/103)

<!-- Reviewable:end -->
