### PR TITLE
Fixing Invite Code Display When There is No Server Available

### DIFF
--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -234,8 +234,12 @@ def user_get_invite_code():
   user_id = json.loads(flask.request.args.get('user_id'))
   user = models.User.query.get_or_404(user_id)
   invite_code = _make_invite_code(user)
-  invite_url = INVITE_CODE_URL_PREFIX + invite_code
-  code_json = json.dumps(({'invite_code': invite_url}))
+  code_json = None
+  if invite_code is None:
+    code_json = json.dumps(({'invite_code': False}))
+  else:
+    invite_url = INVITE_CODE_URL_PREFIX + invite_code
+    code_json = json.dumps(({'invite_code': invite_url}))
   return flask.Response(code_json, mimetype='application/json')
 
 @ufo.app.route('/user/toggleRevoked', methods=['POST'])

--- a/ufo/handlers/user_test.py
+++ b/ufo/handlers/user_test.py
@@ -309,6 +309,17 @@ class UserTest(base_test.BaseTest):
     self.assertEquals(created_user.private_key,
                       invite_code['networkData']['pass'])
 
+  def testUserGetInviteCodeWithoutProxy(self):
+    """Test the user get invite code does not throw an error."""
+    created_user = self._CreateAndSaveFakeUser()
+
+    get_data = {'user_id': created_user.id}
+    resp = self.client.get(flask.url_for('user_get_invite_code'),
+                           query_string=get_data)
+    invite_code = json.loads(resp.data)['invite_code']
+
+    self.assertFalse(invite_code)
+
   def testUserToggleRevokedHandler(self):
     """Test toggle revoked handler changes the revoked status for a user."""
     user = self._CreateAndSaveFakeUser()

--- a/ufo/services/resource_provider.py
+++ b/ufo/services/resource_provider.py
@@ -220,6 +220,10 @@ def _get_user_resources():
     'detailsCloseText': 'Close',
     'detailsButtonId': 'userDetailsButton',
     'detailsOverlayId': 'userDetailsOverlay',
+    'inviteCodeNeedServerText': ('Invite codes aren\'t available without any' +
+                                 ' proxy server configured. Configure a ' +
+                                 'proxy server to have an invite code ' +
+                                 'created automatically.'),
     'inviteCodeLabel': 'Invite Code',
     'privateKeyLabel': 'SSH Private Key',
     'publicKeyLabel': 'SSH Public Key',

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -47,7 +47,7 @@
     <template is="dom-if" if="{{loading}}">
       <paper-spinner id="userDetailsSpinner" active$={{loading}}></paper-spinner>
     </template>
-    <form is="iron-form" method="GET" action="{{resources.inviteCodeUrl}}" loading="{{loading}}" last-response="{{invitCodeJson}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseInviteCodeResponse" hidden id="getInviteCodeAjax">
+    <form is="iron-form" method="GET" action="{{resources.inviteCodeUrl}}" loading="{{loading}}" last-response="{{invitCodeJson}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseInviteCodeResponse" hidden id="getInviteCodeAjax" on-iron-form-error="inviteCodeErrorResponse">
       <input type="hidden" name="user_id" value="{{item.id}}">
     </form>
     <paper-dialog id="{{resources.detailsOverlayId}}" with-backdrop>
@@ -67,16 +67,21 @@
       </paper-listbox>
       <div id="rowHolder" class="vertical center-justified layout">
         <strong>{{resources.inviteCodeLabel}}</strong>
+        <template is="dom-if" if="[[!invitCodeJson.invite_code]]">
+          <p>{{resources.inviteCodeNeedServerText}}</p>
+        </template>
         <paper-input disabled type="text" id="lastInviteCode" value="{{invitCodeJson.invite_code}}"></paper-input>
       </div>
       <br>
       <div class="buttons">
-        <paper-button on-tap="copyInviteCode" class="anchor-button" id="copyInviteCodeButton"><strong>{{resources.copyLabel}}</strong></paper-button>
-        <form is="iron-form" method="post" action="{{resources.rotateKeysUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseRotateResponse" on-iron-form-presubmit="enableSpinner">
-          <input type="hidden" name="user_id" value="{{item.id}}">
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
-          <paper-button on-tap="submitForm" class="anchor-button" id="rotateKeysButton" type="submit"><strong>{{resources.rotateKeysLabel}}</strong></paper-button>
-        </form>
+        <template is="dom-if" if="[[invitCodeJson.invite_code]]">
+          <paper-button on-tap="copyInviteCode" class="anchor-button" id="copyInviteCodeButton"><strong>{{resources.copyLabel}}</strong></paper-button>
+          <form is="iron-form" method="post" action="{{resources.rotateKeysUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseRotateResponse" on-iron-form-presubmit="enableSpinner">
+            <input type="hidden" name="user_id" value="{{item.id}}">
+            <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+            <paper-button on-tap="submitForm" class="anchor-button" id="rotateKeysButton" type="submit"><strong>{{resources.rotateKeysLabel}}</strong></paper-button>
+          </form>
+        </template>
         <form is="iron-form" method="post" action="{{resources.deleteUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
           <input type="hidden" name="user_id" value="{{item.id}}">
           <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
@@ -112,6 +117,7 @@
         },
         invitCodeJson: {
           type: Object,
+          value: false,
           notify: true,
         },
       },
@@ -120,6 +126,10 @@
       },
       enableSpinner: function() {
         this.set('loading', true);
+      },
+      inviteCodeErrorResponse: function() {
+        this.set('loading', false);
+        this.set('invitCodeJson.invite_code', false);
       },
       getXsrfToken: function() {
         return document.getElementById('globalXsrf').value;

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -70,7 +70,9 @@
         <template is="dom-if" if="[[!invitCodeJson.invite_code]]">
           <p>{{resources.inviteCodeNeedServerText}}</p>
         </template>
-        <paper-input disabled type="text" id="lastInviteCode" value="{{invitCodeJson.invite_code}}"></paper-input>
+        <template is="dom-if" if="[[invitCodeJson.invite_code]]">
+          <paper-input disabled type="text" id="lastInviteCode" value="{{invitCodeJson.invite_code}}"></paper-input>
+        </template>
       </div>
       <br>
       <div class="buttons">
@@ -129,7 +131,6 @@
       },
       inviteCodeErrorResponse: function() {
         this.set('loading', false);
-        this.set('invitCodeJson.invite_code', false);
       },
       getXsrfToken: function() {
         return document.getElementById('globalXsrf').value;
@@ -172,7 +173,7 @@
       openDialog: function() {
         var dialog = this.querySelector('#' + this.resources.detailsOverlayId);
         dialog.open();
-        if (!this.invitCodeJson) {
+        if (!this.invitCodeJson.invite_code) {
           this.getUpdatedInviteCode();
         }
       },


### PR DESCRIPTION
Adding notification for why an invite code is not available and making the spinner stop so it doesn't go on indefinitely. Also fixing the server side so it doesn't throw an error.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/110)

<!-- Reviewable:end -->
