### PR TITLE
Handle undefined url by showing an error page to user.

### DIFF
--- a/ufo/services/error_handler.py
+++ b/ufo/services/error_handler.py
@@ -27,6 +27,9 @@ def handle_error(error):
   if not isinstance(error, exceptions.HTTPException):
     error = exceptions.InternalServerError(error.message)
 
+  if error.code == 404:
+    return flask.render_template('error.html', error=error)
+
   return flask.jsonify({'code': error.code,
                         'message': error.description}), error.code
 

--- a/ufo/services/error_handler.py
+++ b/ufo/services/error_handler.py
@@ -27,6 +27,7 @@ def handle_error(error):
   if not isinstance(error, exceptions.HTTPException):
     error = exceptions.InternalServerError(error.message)
 
+  # Show the user an error page, instead of a json message.
   if error.code == 404:
     return flask.render_template('error.html', error=error)
 

--- a/ufo/services/error_handler_test.py
+++ b/ufo/services/error_handler_test.py
@@ -20,8 +20,6 @@ class ErrorHandlerTest(base_test.BaseTest):
     """Test the default HTTP error handlers are registered."""
     app_error_handlers = self.client.application.error_handler_spec[None]
     for error_code in exceptions.default_exceptions:
-      # 404 errors are handled separately as a special case.
-      # It will be covered by a webdriver test.
       self.assertTrue(error_code in app_error_handlers)
 
   def testUnknowExceptionTypesAreHandled(self):

--- a/ufo/services/error_handler_test.py
+++ b/ufo/services/error_handler_test.py
@@ -20,6 +20,8 @@ class ErrorHandlerTest(base_test.BaseTest):
     """Test the default HTTP error handlers are registered."""
     app_error_handlers = self.client.application.error_handler_spec[None]
     for error_code in exceptions.default_exceptions:
+      # 404 errors are handled separately as a special case.
+      # It will be covered by a webdriver test.
       self.assertTrue(error_code in app_error_handlers)
 
   def testUnknowExceptionTypesAreHandled(self):
@@ -34,14 +36,14 @@ class ErrorHandlerTest(base_test.BaseTest):
     self.assertTrue(str(setup_needed_error.code) in resp.data)
     self.assertTrue(SetupNeeded.message in resp.data)
 
-  def testErrorHandlerCanProcessHTTPError(self):
+  def testErrorHandlerCanProcessInternalServerError(self):
     """Test error handler can process HTTP error."""
-    error_404 = exceptions.NotFound()
-    resp = error_handler.handle_error(error_404)
+    error_500 = exceptions.InternalServerError()
+    resp = error_handler.handle_error(error_500)
 
-    self.assertEqual(error_404.code, resp[1])
-    self.assertTrue(str(error_404.code) in resp[0].data)
-    self.assertTrue(error_404.message in resp[0].data)
+    self.assertEqual(error_500.code, resp[1])
+    self.assertTrue(str(error_500.code) in resp[0].data)
+    self.assertTrue(error_500.message in resp[0].data)
 
   def ErrorHandlerCanProcessCustomError(self):
     """Test error handler can process custom error."""

--- a/ufo/templates/error.html
+++ b/ufo/templates/error.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% block body %}
   <div class="horizontal center-justified layout">
-    <paper-card heading="Error">
+    <paper-card>
       <div>
-        <p>{{ error.code }} - {{ error.name }}</p>
+        <p>Error {{ error.code }}</p>
         <p>{{ error.description }}</p>
       </div>
     </paper-card>


### PR DESCRIPTION
- I would have preferred to handle the 404 json response in the frontend, but this is something that's not possible (or easily done).  So, electing to just show the error page to the user.
- Will write a webdriver test for this if this is cool.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/116)

<!-- Reviewable:end -->
