### PR TITLE
Remove Access Column in List Items and Update Formatting

### DIFF
--- a/tests/ui/landing_page_test.py
+++ b/tests/ui/landing_page_test.py
@@ -200,8 +200,6 @@ class LandingPageTest(BaseTest):
         test_user_item, should_use_listbox)
 
     # Get the initial enable/disable text.
-    initial_disabled_enabled_text = container_element.find_element(
-        *LandingPage.USER_DISABLE_ENABLE_TEXT).text
     initial_disabled_enabled_button_text = container_element.find_element(
         *LandingPage.USER_DISABLE_ENABLE_BUTTON).text
 
@@ -221,12 +219,8 @@ class LandingPageTest(BaseTest):
         test_user_item, should_use_listbox)
 
     # Check the enable/disable text changed.
-    changed_disabled_enabled_text = container_element.find_element(
-        *LandingPage.USER_DISABLE_ENABLE_TEXT).text
     changed_disabled_enabled_button_text = container_element.find_element(
         *LandingPage.USER_DISABLE_ENABLE_BUTTON).text
-    self.assertNotEquals(initial_disabled_enabled_text,
-                         changed_disabled_enabled_text)
     self.assertNotEquals(initial_disabled_enabled_button_text,
                          changed_disabled_enabled_button_text)
 
@@ -245,16 +239,10 @@ class LandingPageTest(BaseTest):
         test_user_item, should_use_listbox)
 
     # Check the enable/disable text changed back to the initial.
-    final_disabled_enabled_text = container_element.find_element(
-        *LandingPage.USER_DISABLE_ENABLE_TEXT).text
     final_disabled_enabled_button_text = container_element.find_element(
         *LandingPage.USER_DISABLE_ENABLE_BUTTON).text
-    self.assertNotEquals(changed_disabled_enabled_text,
-                         final_disabled_enabled_text)
     self.assertNotEquals(changed_disabled_enabled_button_text,
                          final_disabled_enabled_button_text)
-    self.assertEquals(initial_disabled_enabled_text,
-                      final_disabled_enabled_text)
     self.assertEquals(initial_disabled_enabled_button_text,
                       final_disabled_enabled_button_text)
 

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -13,13 +13,10 @@
       min-width: 300px;
     }
     .second-div {
-      min-width: 250px;
+      min-width: 350px;
     }
     .third-div {
       min-width: 200px;
-    }
-    .fourth-div {
-      min-width: 100px;
     }
     .topLineButton {
       color: #25CFB9;
@@ -55,8 +52,7 @@
           <iron-icon src="{{resources.itemIconUrl}}" item-icon></iron-icon>
           <div class="first-div"><strong>{{item.name}}</strong></div>
           <div class="second-div">{{item.ip_address}}</div>
-          <div class="third-div"></div>
-          <paper-button on-tap="switchToServerEdit" class="fourth-div topLineButton"><strong>{{resources.editText}}</strong></paper-button>
+          <paper-button on-tap="switchToServerEdit" class="third-div topLineButton"><strong>{{resources.editText}}</strong></paper-button>
           <paper-icon-button icon="close" title="{{resources.detailsCloseText}}" id="{{resources.detailsButtonId}}" on-tap="closeDialog"></paper-icon-button>
         </paper-icon-item>
       </paper-listbox>

--- a/ufo/static/listItems.html
+++ b/ufo/static/listItems.html
@@ -11,27 +11,20 @@
       width: 300px;
     }
     .second-div {
-      width: 250px;
+      width: 350px;
     }
     .third-div {
       width: 200px;
     }
-    .fourth-div {
-      width: 100px;
-    }
     .topLineButton {
-      opacity: 0.0;
       color: #25CFB9;
       text-transform: none;
     }
+    .leftTextAlign {
+      text-align: left;
+    }
     paper-item, paper-icon-item {
       border-top: 1px solid #e5e5e5;
-    }
-    paper-icon-item:hover {
-      @apply(--paper-item-focused);
-    }
-    paper-icon-item:hover .topLineButton {
-      opacity: 1.0;
     }
   </style>
   <!-- TODO(eholder): Figure out how to make hover work with focused. -->
@@ -54,19 +47,17 @@
           <template is="dom-if" if="{{resources.isUser}}">
             <div class="first-div"><strong>{{_limitCharacters(item.name)}}</strong></div>
             <div class="second-div">{{_limitCharacters(item.email)}}</div>
-            <div class="third-div" id="isEnabledDisabledText">{{item.access}}</div>
-            <form is="iron-form" method="post" action="{{resources.revokeToggleUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" class="fourth-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
+            <form is="iron-form" method="post" action="{{resources.revokeToggleUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" class="third-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
               <input type="hidden" name="user_id" value="{{item.id}}">
               <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
-              <paper-button on-tap="submitRevokeForm" class="topLineButton" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>
+              <paper-button on-tap="submitRevokeForm" class="topLineButton leftTextAlign" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>
             </form>
             <user-details-dialog id="detailsHolder" resources="{{resources}}" item="{{item}}"></user-details-dialog>
           </template>
           <template is="dom-if" if="{{resources.isProxyServer}}">
             <div class="first-div"><strong>{{item.name}}</strong></div>
             <div class="second-div">{{item.ip_address}}</div>
-            <div class="third-div"></div>
-            <paper-button on-tap="openServerEdit" class="fourth-div topLineButton"><strong>{{resources.editText}}</strong></paper-button>
+            <paper-button on-tap="openServerEdit" class="third-div topLineButton leftTextAlign"><strong>{{resources.editText}}</strong></paper-button>
             <edit-server-dialog id="detailsHolder" resources="{{resources}}" item="{{item}}"></edit-server-dialog>
           </template>
           <paper-icon-button icon="expand-more" title="{{resources.detailsExpandText}}" id="{{resources.detailsButtonId}}"></paper-icon-button>
@@ -108,7 +99,7 @@
         },
         characterLimit: {
           type: Number,
-          value: 25,
+          value: 40,
         },
         autoGet: {
           type: Boolean,

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -13,13 +13,10 @@
       min-width: 300px;
     }
     .second-div {
-      min-width: 250px;
+      min-width: 350px;
     }
     .third-div {
       min-width: 200px;
-    }
-    .fourth-div {
-      min-width: 100px;
     }
     .topLineButton {
       color: #25CFB9;
@@ -56,8 +53,7 @@
           <iron-icon src="{{resources.itemIconUrl}}" item-icon></iron-icon>
           <div class="first-div"><strong>{{item.name}}</strong></div>
           <div class="second-div">{{item.email}}</div>
-          <div class="third-div" id="isEnabledDisabledText">{{item.access}}</div>
-          <form is="iron-form" method="post" action="{{resources.revokeToggleUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" class="fourth-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
+          <form is="iron-form" method="post" action="{{resources.revokeToggleUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" class="third-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
             <input type="hidden" name="user_id" value="{{item.id}}">
             <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
             <paper-button on-tap="submitForm" class="topLineButton" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>


### PR DESCRIPTION
This removes the "Access Enabled/Disabled" text on the user listing on the landing page. It also is removed from the details views and the format is changed slightly to add more room for the email address field.

This change was part of Michael's suggestions for an easier to use enable/disable flow. See screenshot attached for new look:
![ufolistitemscolumns](https://cloud.githubusercontent.com/assets/6269245/14436631/7749f80a-ffd2-11e5-865d-708b81bc57f1.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/119)

<!-- Reviewable:end -->
