### PR TITLE
Fix invite code to use username instead of email.

### DIFF
--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -121,7 +121,7 @@ def _make_invite_code(user):
       'networkName': 'Cloud',
       'networkData': {
         'host': ip,
-        'user': user.email.split("@")[0],  # username
+        'user': user.email.split("@")[0],
         'pass': user.private_key,
       },
   }

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -121,7 +121,7 @@ def _make_invite_code(user):
       'networkName': 'Cloud',
       'networkData': {
         'host': ip,
-        'user': user.email,
+        'user': user.email.split("@")[0],  # username
         'pass': user.private_key,
       },
   }

--- a/ufo/handlers/user_test.py
+++ b/ufo/handlers/user_test.py
@@ -305,7 +305,8 @@ class UserTest(base_test.BaseTest):
 
     self.assertEquals('Cloud', invite_code['networkName'])
     self.assertEquals(fake_ip, invite_code['networkData']['host'])
-    self.assertEquals(created_user.email, invite_code['networkData']['user'])
+    self.assertEquals(created_user.email.split("@")[0],
+                      invite_code['networkData']['user'])
     self.assertEquals(created_user.private_key,
                       invite_code['networkData']['pass'])
 


### PR DESCRIPTION
Trevor confirmed that we need to use the username in the invite code, instead of email.

{
  "networkName": "Cloud",
  "networkData": "{
    \"host\":\"mybox.mydomain.org\",
    \"user\":\"trevj\",
    \"key\":\"<foo_user_private_key>"
  }"
}

It might help to remember that the cloud provider, given this invite, will essentially run:
ssh trevj@mybox.mydomain.org -i <path to foo_user_private_key>

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/129)

<!-- Reviewable:end -->
