### PR TITLE
Swapping the Edit Server Textare for an Input Box so that it at Least Works for the Moment

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "paper-drawer-panel": "PolymerElements/paper-drawer-panel#~1.0.6",
     "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#~1.1.3",
     "paper-icon-button": "PolymerElements/paper-icon-button#~1.0.6",
-    "paper-input": "PolymerElements/paper-input#~1.1.3",
+    "paper-input": "PolymerElements/paper-input#~1.1.11",
     "paper-item": "PolymerElements/paper-item#~1.1.2",
     "paper-listbox": "PolymerElements/paper-listbox#~1.1.0",
     "paper-material": "PolymerElements/paper-material#~1.0.6",

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -4,8 +4,9 @@
 <link rel="import" href="bower_components/paper-dialog/paper-dialog.html" />
 <link rel="import" href="bower_components/paper-input/paper-input.html" />
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
-<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />>
+<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/paper-input/paper-textarea.html" />
 
 <dom-module id="edit-server-dialog">
   <style is="custom-style">
@@ -64,7 +65,7 @@
           <paper-input class="editInputFields" disabled label="{{resources.ipLabel}}" type="text" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" value="[[item.ip_address]]" on-keypress="submitIfEnter"></paper-input>
           <paper-input class="editInputFields" disabled label="{{resources.nameLabel}}" type="text" name="name" required value="[[item.name]]" on-keypress="submitIfEnter"></paper-input>
           <!-- TODO add the ability to upload files -->
-          <ufo-textarea class="editInputFields" disabled label="{{resources.privateKeyLabel}}" name="private_key" required max-rows="{{resources.textAreaMaxRows}}" pattern="{{resources.regexes.privateKeyPattern}}" error-message="{{resources.regexes.privateKeyError}}" value="[[item.private_key]]" on-keypress="submitIfEnter"></ufo-textarea>
+          <paper-input class="editInputFields" disabled label="[[resources.privateKeyLabel]]" name="private_key" required max-rows="[[resources.textAreaMaxRows]]" pattern="[[resources.regexes.privateKeyPattern]]" error-message="[[resources.regexes.privateKeyError]]" value="[[item.private_key]]" on-keypress="submitIfEnter"></paper-input>
           <br>
           <p class="editElements hideElement">{{resources.privateKeyText}}</p>
 

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -6,7 +6,7 @@
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
-<link rel="import" href="bower_components/paper-input/paper-textarea.html" />
+<link rel="import" href="textarea.html" />
 
 <dom-module id="edit-server-dialog">
   <style is="custom-style">
@@ -65,7 +65,7 @@
           <paper-input class="editInputFields" disabled label="{{resources.ipLabel}}" type="text" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" value="[[item.ip_address]]" on-keypress="submitIfEnter"></paper-input>
           <paper-input class="editInputFields" disabled label="{{resources.nameLabel}}" type="text" name="name" required value="[[item.name]]" on-keypress="submitIfEnter"></paper-input>
           <!-- TODO add the ability to upload files -->
-          <paper-input class="editInputFields" disabled label="[[resources.privateKeyLabel]]" name="private_key" required max-rows="[[resources.textAreaMaxRows]]" pattern="[[resources.regexes.privateKeyPattern]]" error-message="[[resources.regexes.privateKeyError]]" value="[[item.private_key]]" on-keypress="submitIfEnter"></paper-input>
+          <paper-input class="editInputFields" disabled label="[[resources.privateKeyLabel]]" name="private_key" required max-rows="[[resources.textAreaMaxRows]]" pattern="[[resources.regexes.privateKeyPattern]]" error-message="[[resources.regexes.privateKeyError]]" value="[[item.private_key]]"></paper-input>
           <br>
           <p class="editElements hideElement">{{resources.privateKeyText}}</p>
 

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -23,7 +23,7 @@
         <paper-input label="{{resources.ipLabel}}" type="text" id="ipInput" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" on-keypress="submitIfEnter">{{resources.ip_address}}</paper-input>
         <paper-input label="{{resources.nameLabel}}" type="text" id="nameInput" name="name" required on-keypress="submitIfEnter">{{resources.name}}</paper-input>
         <!-- TODO add the ability to upload files -->
-        <ufo-textarea label="{{resources.privateKeyLabel}}" id="privateKeyInput" name="private_key" required max-rows="{{resources.textAreaMaxRows}}" pattern="{{resources.regexes.privateKeyPattern}}" error-message="{{resources.regexes.privateKeyError}}" value="{{resources.private_key}}" on-keypress="submitIfEnter"></ufo-textarea>
+        <ufo-textarea label="{{resources.privateKeyLabel}}" id="privateKeyInput" name="private_key" required max-rows="{{resources.textAreaMaxRows}}" pattern="{{resources.regexes.privateKeyPattern}}" error-message="{{resources.regexes.privateKeyError}}" value="{{resources.private_key}}"></ufo-textarea>
         <br>
         <p>{{resources.privateKeyText}}</p>
 

--- a/ufo/static/textarea.html
+++ b/ufo/static/textarea.html
@@ -23,44 +23,44 @@
 
     <input type="hidden" name$="[[name]]" value="{{value}}" />
   </template>
-</dom-module>
 
-<script>
-  Polymer({
-    is: 'ufo-textarea',
-    properties: {
-      name: {
-        type: String
-      },
-      label: {
-        type: String
-      },
-      disabled: {
-        type: Boolean,
-        value: false
-      },
-      required: {
-        type: Boolean,
-        value: false
-      },
-      autoValidate: {
-        type: Boolean,
-        value: false
-      },
-      pattern: {
-        type: String
-      },
-      errorMessage: {
-        type: String
-      },
-      value: {
-        notify: true,
-        type: String
-      },
-      maxRows: {
-        type: Number,
-        value: 10,
-      },
-    }
-  });
-</script>
+  <script>
+    Polymer({
+      is: 'ufo-textarea',
+      properties: {
+        name: {
+          type: String
+        },
+        label: {
+          type: String
+        },
+        disabled: {
+          type: Boolean,
+          value: false
+        },
+        required: {
+          type: Boolean,
+          value: false
+        },
+        autoValidate: {
+          type: Boolean,
+          value: false
+        },
+        pattern: {
+          type: String
+        },
+        errorMessage: {
+          type: String
+        },
+        value: {
+          notify: true,
+          type: String
+        },
+        maxRows: {
+          type: Number,
+          value: 10,
+        },
+      }
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
Cleaned up a few things with our custom textarea as well, but the changes there did not actually fix the problem.

By my best estimation, the problem is that we somehow trigger an infinite event loop which causes the page to overflow infinitely and eventually freeze. The textarea itself doesn't seem to be the cause of the problem, as this overflow behavior actually occurs on the other inputs within the edit server dialog as well. To verify this, go to any standing management server, open up dev console (F12), add a proxy server, click "Edit" on that proxy server to bring up the edit flow, and then click into the IP Address, Server Name, or SSH Host Public Key field (not the SSH Private Key field which causes the infinite overflow). You will see that the error (Uncaught RangeError: Maximum call stack size exceeded) is displayed about 5 times, but does stop allowing you to continue navigating. This happens fast enough that without dev console, it isn't even noticeable that the error even occurs.

The strange thing is that although those other inputs trigger the overflow too, they only seem to trigger it about 5 times, which isn't enough for it to continue infinitely for some reason. I attempted removing our custom ufo-textarea element (which wraps a standard html input and a paper-textarea element) in favor or the standard paper-textarea element, but the problem persisted. I fear that something broken in the textarea upstream makes this trigger more than the standard paper-input which results in the much worse infinite loop of overflows rather than just 5 overflows.

Switching to a paper-input reduces the overflows down to 5, which removes the problem of freezing. This makes the private key much harder to edit however, and the overflows are still occurring so I'll have to investigate further as to why this is happening.

For another added wrinkle, I tried to replicate this behavior in a jsbin to send over to the paper-input repo for Polymer to see if they could help. In spite of recreating much of the structure of our custom elements in the jsbin, the freezing behavior is actually eliminated entirely there. It is worth noting that the jsbin has far fewer elements (I stripped it down to the most relevant while retaining pieces which I thought might cause the problem) and is not vulcanized, each of which could contribute to the problem. Have a look here if you're curious: http://jsbin.com/kenizufeji/1/edit?html,output

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/134)

<!-- Reviewable:end -->
