### PR TITLE
Fixing the Copy Invite Code Button

### DIFF
--- a/ufo/static/globalHelperFunctions.js
+++ b/ufo/static/globalHelperFunctions.js
@@ -13,3 +13,19 @@ var submitUsersManually = function() {
   input.value = JSON.stringify(userArray);
   formElem.submit();
 };
+
+
+(function() {
+  'use strict';
+  document.body.addEventListener('copy', copyInviteCodeToClipboard, true);
+
+  function copyInviteCodeToClipboard(e) {
+    if (e.target !== document.body) {
+      return;
+    }
+    e.preventDefault();
+
+    var input = document.getElementById('hiddenCopyInput');
+    e.clipboardData.setData('text/plain', input.value);
+  }
+})();

--- a/ufo/static/globalHelperFunctions.js
+++ b/ufo/static/globalHelperFunctions.js
@@ -14,7 +14,13 @@ var submitUsersManually = function() {
   formElem.submit();
 };
 
-
+/**
+ * I had to do this outside of a custom element because of the way that the
+ * browser handles permissions for using the document.execCommand and
+ * clipboardData API's. In essence, it doesn't like how Polymer registers and
+ * fire event handlers and won't let you touch clipboardData from there, thus
+ * the Javascript is outside of Polymer.
+ */
 (function() {
   'use strict';
   document.body.addEventListener('copy', copyInviteCodeToClipboard, true);

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -38,6 +38,9 @@
     .spacer {
       width: 20px;
     }
+    .buttons paper-button {
+      height: 40px;
+    }
   </style>
   <!-- TODO(eholder): Figure out how to make hover work with focused. -->
   <template>
@@ -73,11 +76,15 @@
       <br>
       <div class="buttons">
         <template is="dom-if" if="[[invitCodeJson.invite_code]]">
-          <paper-button on-tap="copyInviteCode" class="anchor-button" id="copyInviteCodeButton"><strong>{{resources.copyLabel}}</strong></paper-button>
+          <paper-button on-tap="copyInviteCode" class="anchor-button" id="copyInviteCodeButton" type="submit">
+            <iron-icon icon="content-copy"></iron-icon> <strong>{{resources.copyLabel}}</strong>
+          </paper-button>
           <form is="iron-form" method="post" action="{{resources.rotateKeysUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseRotateResponse" on-iron-form-presubmit="enableSpinner">
             <input type="hidden" name="user_id" value="{{item.id}}">
             <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
-            <paper-button on-tap="submitForm" class="anchor-button" id="rotateKeysButton" type="submit"><strong>{{resources.rotateKeysLabel}}</strong></paper-button>
+            <paper-button on-tap="submitForm" class="anchor-button" id="rotateKeysButton" type="submit">
+              <iron-icon icon="refresh"></iron-icon> <strong>{{resources.rotateKeysLabel}}</strong>
+            </paper-button>
           </form>
         </template>
         <form is="iron-form" method="post" action="{{resources.deleteUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
@@ -177,16 +184,12 @@
         var dialog = this.querySelector('#' + this.resources.detailsOverlayId);
         dialog.close();
       },
-      copyInviteCode: function(e, details) {
-        var elem = this.$.lastInviteCode;
-        var input = document.createElement('input');
-        input.style.position = 'fixed';
-        input.style.zIndex = '-1';
-        input.value = elem.value;
-        document.body.appendChild(input);
+      copyInviteCode: function(e) {
+        var elem = this.querySelector('#lastInviteCode');
+        var input = document.getElementById('hiddenCopyInput');
+        input.setAttribute('value', elem.value);
         input.select();
         document.execCommand('copy');
-        document.body.removeChild(input);
       },
       getUpdatedInviteCode: function() {
         this.$.getInviteCodeAjax.submit()

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -30,6 +30,10 @@
   #dialogMenuHolder {
     position: absolute;
   }
+  #hiddenCopyInput {
+    position: fixed;
+    zIndex: -1;
+  }
 </style>
 <body class="fullbleed layout vertical">
   <div>  <!-- Prevent the main-holder from pushing into the header. -->
@@ -69,5 +73,6 @@
   <error-notification id='error-notification'></error-notification>
 
   <script src="{{ url_for('static', filename='globalHelperFunctions.js') }}"></script>
+  <input id="hiddenCopyInput" value=""/>
 </body>
 </html>

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -32,10 +32,6 @@
   #dialogMenuHolder {
     position: absolute;
   }
-  #hiddenCopyInput {
-    position: fixed;
-    z-index: -1;
-  }
 </style>
 <body class="fullbleed layout vertical">
   <div>  <!-- Prevent the main-holder from pushing into the header. -->
@@ -75,6 +71,6 @@
   <error-notification id='error-notification'></error-notification>
 
   <script src="{{ url_for('static', filename='globalHelperFunctions.js') }}"></script>
-  <input id="hiddenCopyInput" value=""/>
+  <input id="hiddenCopyInput" type="hidden" value=""/>
 </body>
 </html>

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -32,7 +32,7 @@
   }
   #hiddenCopyInput {
     position: fixed;
-    zIndex: -1;
+    z-index: -1;
   }
 </style>
 <body class="fullbleed layout vertical">


### PR DESCRIPTION
We have to use a different event listener format for it to trigger properly in Chrome. The copy command doesn't actually pick up the necessary data to be copied, so we intercept that event, check that it is the event we just triggered, and let it pass if not or set the necessary data if so. Kind of a pain, but it works now.

Also, I cleaned up how our copy functions by having one static hidden node in the dom to put the content onto then copy from (rather than dynamically generating and destroying a node each time). I fixed the height on the buttons in the details dialog so that they are uniform as well. Finally, I added icons to the copy and create new code buttons.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/135)

<!-- Reviewable:end -->
