### PR TITLE
Fix queued job not running.

### DIFF
--- a/clock.py
+++ b/clock.py
@@ -2,6 +2,8 @@
 
 https://devcenter.heroku.com/articles/clock-processes-python
 """
+import logging
+
 # Use the default import to avoid module AttributeError (http://goo.gl/YM7kyZ)
 from apscheduler.schedulers.blocking import BlockingScheduler
 
@@ -9,6 +11,9 @@ import ufo
 from ufo.services import key_distributor
 from ufo.services import user_synchronizer
 
+
+# http://stackoverflow.com/questions/28724459/no-handlers-could-be-found-for-logger-apscheduler-executors-default
+logging.basicConfig()
 
 SCHEDULER = BlockingScheduler()
 


### PR DESCRIPTION
My heroku dev instance somehow got hosed where no enqueued job would run.  Doing a flushall on the redis db helped to expose this error:
`No handlers could be found for logger “apscheduler.executors.default”`
which the commented SO thread ended up solving the problem.

The curious thing is that this happened only to my instance but not on nightly.  But this change should be not be harmful.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/143)

<!-- Reviewable:end -->
