### PR TITLE
JSON Security and Content Type to Block XSS

### DIFF
--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -37,11 +37,7 @@ whooshalchemy.whoosh_index(app, models.User)
 whooshalchemy.whoosh_index(app, models.ProxyServer)
 
 JSON_HEADERS = {'Content-Type': 'application/javascript; charset=utf-8'}
-JSON_PREFIX_FOR_HTML = ")]}'"
-# JSON_PREFIX_FOR_HTML is the value that gets stripped in the client side, not
-# JSON_PREFIX since handling the extra new line character is difficult.
-# JSON_PREFIX is the value that gets prefixed server side.
-JSON_PREFIX = JSON_PREFIX_FOR_HTML + "\n"
+JSON_PREFIX = ")]}'\n"
 
 @app.after_request
 def checkCredentialChange(response):

--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -36,6 +36,13 @@ from ufo.database import models
 whooshalchemy.whoosh_index(app, models.User)
 whooshalchemy.whoosh_index(app, models.ProxyServer)
 
+JSON_HEADERS = {'Content-Type': 'application/javascript; charset=utf-8'}
+JSON_PREFIX_FOR_HTML = ")]}'"
+# JSON_PREFIX_FOR_HTML is the value that gets stripped in the client side, not
+# JSON_PREFIX since handling the extra new line character is difficult.
+# JSON_PREFIX is the value that gets prefixed server side.
+JSON_PREFIX = JSON_PREFIX_FOR_HTML + "\n"
+
 @app.after_request
 def checkCredentialChange(response):
   """Save credentials if changed"""

--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -36,8 +36,14 @@ from ufo.database import models
 whooshalchemy.whoosh_index(app, models.User)
 whooshalchemy.whoosh_index(app, models.ProxyServer)
 
+# The headers and prefix listed below are to help guard against XSSI. The
+# prefix specifically causes us to escape out of any client that attempts to
+# execute the JSON as code. We don't use any callbacks or functions in our
+# returned JSON, but the prefix would catch it by causing execution to stop if
+# so. The prefix is supplied in the resource dictionaries so that it can be
+# stripped away on the client side when making AJAX calls.
 JSON_HEADERS = {'Content-Type': 'application/javascript; charset=utf-8'}
-JSON_PREFIX = ")]}'\n"
+XSSI_PREFIX = ")]}'\n"
 
 @app.after_request
 def checkCredentialChange(response):

--- a/ufo/handlers/admin.py
+++ b/ufo/handlers/admin.py
@@ -21,7 +21,8 @@ def admin_list():
     A json object with 'items' set to the list of admins in the db.
   """
   items_dict = {'items': models.AdminUser.get_items_as_list_of_dict()}
-  return flask.Response(json.dumps((items_dict)), mimetype='application/json')
+  return flask.Response(ufo.JSON_PREFIX + json.dumps((items_dict)),
+                        headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/admin/add', methods=['POST'])
 @ufo.setup_required

--- a/ufo/handlers/admin.py
+++ b/ufo/handlers/admin.py
@@ -21,7 +21,7 @@ def admin_list():
     A json object with 'items' set to the list of admins in the db.
   """
   items_dict = {'items': models.AdminUser.get_items_as_list_of_dict()}
-  return flask.Response(ufo.JSON_PREFIX + json.dumps((items_dict)),
+  return flask.Response(ufo.XSSI_PREFIX + json.dumps((items_dict)),
                         headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/admin/add', methods=['POST'])

--- a/ufo/handlers/admin_test.py
+++ b/ufo/handlers/admin_test.py
@@ -33,7 +33,7 @@ class AdminTest(base_test.BaseTest):
   def testListAdminsHandler(self):
     """Test the list admin handler gets admins from the database."""
     resp = self.client.get(flask.url_for('admin_list'))
-    admin_list_output = json.loads(resp.data[len(ufo.JSON_PREFIX):])['items']
+    admin_list_output = json.loads(resp.data[len(ufo.XSSI_PREFIX):])['items']
 
     self.assertEquals(len(admin_list_output), 1)
     test_admin = admin_list_output[0]

--- a/ufo/handlers/admin_test.py
+++ b/ufo/handlers/admin_test.py
@@ -6,6 +6,7 @@ import flask
 from mock import MagicMock
 from mock import patch
 
+import ufo
 from ufo import base_test
 from ufo.database import models
 from ufo.handlers import admin
@@ -32,7 +33,7 @@ class AdminTest(base_test.BaseTest):
   def testListAdminsHandler(self):
     """Test the list admin handler gets admins from the database."""
     resp = self.client.get(flask.url_for('admin_list'))
-    admin_list_output = json.loads(resp.data)['items']
+    admin_list_output = json.loads(resp.data[len(ufo.JSON_PREFIX):])['items']
 
     self.assertEquals(len(admin_list_output), 1)
     test_admin = admin_list_output[0]

--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -45,5 +45,5 @@ def download_chrome_policy():
   Returns:
     A json file of the current managed chrome policy.
   """
-  return flask.Response(ufo.JSON_PREFIX + _make_chrome_policy_json(),
+  return flask.Response(ufo.XSSI_PREFIX + _make_chrome_policy_json(),
                         headers=ufo.JSON_HEADERS)

--- a/ufo/handlers/chrome_policy.py
+++ b/ufo/handlers/chrome_policy.py
@@ -45,5 +45,5 @@ def download_chrome_policy():
   Returns:
     A json file of the current managed chrome policy.
   """
-  return flask.Response(_make_chrome_policy_json(),
-                        mimetype='application/json')
+  return flask.Response(ufo.JSON_PREFIX + _make_chrome_policy_json(),
+                        headers=ufo.JSON_HEADERS)

--- a/ufo/handlers/chrome_policy_test.py
+++ b/ufo/handlers/chrome_policy_test.py
@@ -23,7 +23,7 @@ class ChromePolicyTest(base_test.BaseTest):
     """Test the chrome policy download handler downloads json."""
     resp = self.client.get(flask.url_for('download_chrome_policy'))
 
-    json_data = json.loads(resp.data)
+    json_data = json.loads(resp.data[len(ufo.JSON_PREFIX):])
     self.assertIn('validProxyServers', json_data)
     self.assertIn('enforceProxyServerValidity', json_data)
     self.assertNotIn('enforce_network_jail', json_data)

--- a/ufo/handlers/chrome_policy_test.py
+++ b/ufo/handlers/chrome_policy_test.py
@@ -23,7 +23,7 @@ class ChromePolicyTest(base_test.BaseTest):
     """Test the chrome policy download handler downloads json."""
     resp = self.client.get(flask.url_for('download_chrome_policy'))
 
-    json_data = json.loads(resp.data[len(ufo.JSON_PREFIX):])
+    json_data = json.loads(resp.data[len(ufo.XSSI_PREFIX):])
     self.assertIn('validProxyServers', json_data)
     self.assertIn('enforceProxyServerValidity', json_data)
     self.assertNotIn('enforce_network_jail', json_data)

--- a/ufo/handlers/proxy_server.py
+++ b/ufo/handlers/proxy_server.py
@@ -17,7 +17,8 @@ from ufo.services import custom_exceptions
 def proxyserver_list():
   proxy_server_dict = {'items': models.ProxyServer.get_items_as_list_of_dict()}
   proxy_servers_json = json.dumps((proxy_server_dict))
-  return flask.Response(proxy_servers_json, mimetype='application/json')
+  return flask.Response(ufo.JSON_PREFIX + proxy_servers_json,
+                        headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/proxyserver/add', methods=['GET', 'POST'])
 @ufo.setup_required
@@ -69,7 +70,7 @@ def proxyserver_edit():
   server.read_private_key_from_file_contents(private_key_contents)
   server.save()
 
-  return flask.redirect(flask.url_for('proxyserver_list'))
+  return proxyserver_list()
 
 @ufo.app.route('/proxyserver/delete', methods=['POST'])
 @ufo.setup_required

--- a/ufo/handlers/proxy_server.py
+++ b/ufo/handlers/proxy_server.py
@@ -17,7 +17,7 @@ from ufo.services import custom_exceptions
 def proxyserver_list():
   proxy_server_dict = {'items': models.ProxyServer.get_items_as_list_of_dict()}
   proxy_servers_json = json.dumps((proxy_server_dict))
-  return flask.Response(ufo.JSON_PREFIX + proxy_servers_json,
+  return flask.Response(ufo.XSSI_PREFIX + proxy_servers_json,
                         headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/proxyserver/add', methods=['GET', 'POST'])

--- a/ufo/handlers/proxy_server.py
+++ b/ufo/handlers/proxy_server.py
@@ -70,7 +70,7 @@ def proxyserver_edit():
   server.read_private_key_from_file_contents(private_key_contents)
   server.save()
 
-  return proxyserver_list()
+  return flask.redirect(flask.url_for('proxyserver_list'))
 
 @ufo.app.route('/proxyserver/delete', methods=['POST'])
 @ufo.setup_required

--- a/ufo/handlers/search.py
+++ b/ufo/handlers/search.py
@@ -44,7 +44,7 @@ def search():
     'servers': _search_proxy_server(search_text),
   }
   results_json = json.dumps((results_dict))
-  return flask.Response(ufo.JSON_PREFIX + results_json,
+  return flask.Response(ufo.XSSI_PREFIX + results_json,
                         headers=ufo.JSON_HEADERS)
 
 def _search_user(search_text):

--- a/ufo/handlers/search.py
+++ b/ufo/handlers/search.py
@@ -44,7 +44,8 @@ def search():
     'servers': _search_proxy_server(search_text),
   }
   results_json = json.dumps((results_dict))
-  return flask.Response(results_json, mimetype='application/json')
+  return flask.Response(ufo.JSON_PREFIX + results_json,
+                        headers=ufo.JSON_HEADERS)
 
 def _search_user(search_text):
   """Gets the database users matching the search term.

--- a/ufo/handlers/settings.py
+++ b/ufo/handlers/settings.py
@@ -34,7 +34,8 @@ def get_settings():
   Returns:
     A flask response with the json settings.
   """
-  return flask.Response(_make_settings_json(), mimetype='application/json')
+  return flask.Response(ufo.JSON_PREFIX + _make_settings_json(),
+                        headers=ufo.JSON_HEADERS)
 
 
 @ufo.app.route('/chromepolicy/edit', methods=['POST'])

--- a/ufo/handlers/settings.py
+++ b/ufo/handlers/settings.py
@@ -34,7 +34,7 @@ def get_settings():
   Returns:
     A flask response with the json settings.
   """
-  return flask.Response(ufo.JSON_PREFIX + _make_settings_json(),
+  return flask.Response(ufo.XSSI_PREFIX + _make_settings_json(),
                         headers=ufo.JSON_HEADERS)
 
 

--- a/ufo/handlers/settings_test.py
+++ b/ufo/handlers/settings_test.py
@@ -23,7 +23,7 @@ class SettingsTest(base_test.BaseTest):
     """Test the get settings handler downloads json."""
     resp = self.client.get(flask.url_for('get_settings'))
 
-    json_data = json.loads(resp.data)
+    json_data = json.loads(resp.data[len(ufo.JSON_PREFIX):])
     self.assertNotIn('validProxyServers', json_data)
     self.assertIn('enforce_proxy_server_validity', json_data)
     self.assertIn('enforce_network_jail', json_data)

--- a/ufo/handlers/settings_test.py
+++ b/ufo/handlers/settings_test.py
@@ -23,7 +23,7 @@ class SettingsTest(base_test.BaseTest):
     """Test the get settings handler downloads json."""
     resp = self.client.get(flask.url_for('get_settings'))
 
-    json_data = json.loads(resp.data[len(ufo.JSON_PREFIX):])
+    json_data = json.loads(resp.data[len(ufo.XSSI_PREFIX):])
     self.assertNotIn('validProxyServers', json_data)
     self.assertIn('enforce_proxy_server_validity', json_data)
     self.assertIn('enforce_network_jail', json_data)

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -40,7 +40,7 @@ def _get_users_to_add(get_all, group_key, user_key):
   if not credentials:
     dictionary = {'directory_users': [], 'error': 'OAuth is not set up'}
     json_obj = json.dumps((dictionary))
-    return flask.Response(json_obj, mimetype='application/json')
+    return flask.Response(ufo.JSON_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
 
   try:
     directory_service = google_directory_service.GoogleDirectoryService(
@@ -63,11 +63,11 @@ def _get_users_to_add(get_all, group_key, user_key):
       users_to_output.append(user_for_display)
 
     json_obj = json.dumps(({'directory_users': users_to_output}))
-    return flask.Response(json_obj, mimetype='application/json')
+    return flask.Response(ufo.JSON_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
 
   except errors.HttpError as error:
     json_obj = json.dumps(({'directory_users': [], 'error': str(error)}))
-    return flask.Response(json_obj, mimetype='application/json')
+    return flask.Response(ufo.JSON_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
 
 def _get_random_server_ip():
   """Gets the ip address of a random proxy server of those in the db.
@@ -140,7 +140,7 @@ def user_list():
     A json object with 'items' set to the list of users in the db.
   """
   users_json = json.dumps(({'items': models.User.get_items_as_list_of_dict()}))
-  return flask.Response(users_json, mimetype='application/json')
+  return flask.Response(ufo.JSON_PREFIX + users_json, headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/user/add', methods=['GET', 'POST'])
 @ufo.setup_required
@@ -240,7 +240,7 @@ def user_get_invite_code():
   else:
     invite_url = INVITE_CODE_URL_PREFIX + invite_code
     code_json = json.dumps(({'invite_code': invite_url}))
-  return flask.Response(code_json, mimetype='application/json')
+  return flask.Response(ufo.JSON_PREFIX + code_json, headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/user/toggleRevoked', methods=['POST'])
 @ufo.setup_required

--- a/ufo/handlers/user.py
+++ b/ufo/handlers/user.py
@@ -40,7 +40,7 @@ def _get_users_to_add(get_all, group_key, user_key):
   if not credentials:
     dictionary = {'directory_users': [], 'error': 'OAuth is not set up'}
     json_obj = json.dumps((dictionary))
-    return flask.Response(ufo.JSON_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
+    return flask.Response(ufo.XSSI_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
 
   try:
     directory_service = google_directory_service.GoogleDirectoryService(
@@ -63,11 +63,11 @@ def _get_users_to_add(get_all, group_key, user_key):
       users_to_output.append(user_for_display)
 
     json_obj = json.dumps(({'directory_users': users_to_output}))
-    return flask.Response(ufo.JSON_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
+    return flask.Response(ufo.XSSI_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
 
   except errors.HttpError as error:
     json_obj = json.dumps(({'directory_users': [], 'error': str(error)}))
-    return flask.Response(ufo.JSON_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
+    return flask.Response(ufo.XSSI_PREFIX + json_obj, headers=ufo.JSON_HEADERS)
 
 def _get_random_server_ip():
   """Gets the ip address of a random proxy server of those in the db.
@@ -140,7 +140,7 @@ def user_list():
     A json object with 'items' set to the list of users in the db.
   """
   users_json = json.dumps(({'items': models.User.get_items_as_list_of_dict()}))
-  return flask.Response(ufo.JSON_PREFIX + users_json, headers=ufo.JSON_HEADERS)
+  return flask.Response(ufo.XSSI_PREFIX + users_json, headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/user/add', methods=['GET', 'POST'])
 @ufo.setup_required
@@ -240,7 +240,7 @@ def user_get_invite_code():
   else:
     invite_url = INVITE_CODE_URL_PREFIX + invite_code
     code_json = json.dumps(({'invite_code': invite_url}))
-  return flask.Response(ufo.JSON_PREFIX + code_json, headers=ufo.JSON_HEADERS)
+  return flask.Response(ufo.XSSI_PREFIX + code_json, headers=ufo.JSON_HEADERS)
 
 @ufo.app.route('/user/toggleRevoked', methods=['POST'])
 @ufo.setup_required

--- a/ufo/handlers/user_test.py
+++ b/ufo/handlers/user_test.py
@@ -10,6 +10,7 @@ from mock import patch
 from werkzeug.datastructures import MultiDict
 from werkzeug.datastructures import ImmutableMultiDict
 
+import ufo
 from ufo import base_test
 from ufo.database import models
 from ufo.handlers import user
@@ -66,7 +67,7 @@ class UserTest(base_test.BaseTest):
       users.append(user)
 
     resp = self.client.get(flask.url_for('user_list'))
-    user_list_output = json.loads(resp.data)['items']
+    user_list_output = json.loads(resp.data[len(ufo.JSON_PREFIX):])['items']
 
     self.assertEquals(len(user_list_output),
                       len(base_test.FAKE_EMAILS_AND_NAMES))
@@ -94,10 +95,10 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user'))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0])
+    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
     self.assertEquals([], json_output['directory_users'])
     self.assertIsNotNone(json_output['error'])
-    self.assertEquals('application/json', kwargs['mimetype'])
+    self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
 
   @patch('flask.Response')
   @patch.object(oauth, 'getSavedCredentials')
@@ -112,9 +113,9 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user'))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0])
+    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
     self.assertEquals([], json_output['directory_users'])
-    self.assertEquals('application/json', kwargs['mimetype'])
+    self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
 
   @patch('flask.Response')
   @patch.object(oauth, 'getSavedCredentials')
@@ -134,10 +135,10 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user', group_key=group_key))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0])
+    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
     self.assertEquals(FAKE_USERS_FOR_DISPLAY_ARRAY,
                       json_output['directory_users'])
-    self.assertEquals('application/json', kwargs['mimetype'])
+    self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
 
   @patch('flask.Response')
   @patch.object(oauth, 'getSavedCredentials')
@@ -157,10 +158,10 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user', user_key=user_key))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0])
+    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
     self.assertEquals(FAKE_USERS_FOR_DISPLAY_ARRAY,
                       json_output['directory_users'])
-    self.assertEquals('application/json', kwargs['mimetype'])
+    self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
 
   @patch('flask.Response')
   @patch.object(oauth, 'getSavedCredentials')
@@ -178,10 +179,10 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user', get_all=True))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0])
+    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
     self.assertEquals(FAKE_USERS_FOR_DISPLAY_ARRAY,
                       json_output['directory_users'])
-    self.assertEquals('application/json', kwargs['mimetype'])
+    self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
 
   @patch('flask.Response')
   @patch.object(oauth, 'getSavedCredentials')
@@ -207,10 +208,10 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user'))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0])
+    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
     self.assertEquals([], json_output['directory_users'])
     self.assertEquals(str(fake_error), json_output['error'])
-    self.assertEquals('application/json', kwargs['mimetype'])
+    self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
 
   def testAddUsersPostHandler(self):
     """Test the add users post handler calls to insert the specified users."""
@@ -296,7 +297,8 @@ class UserTest(base_test.BaseTest):
     get_data = {'user_id': created_user.id}
     resp = self.client.get(flask.url_for('user_get_invite_code'),
                            query_string=get_data)
-    invite_url = str(json.loads(resp.data)['invite_code'])
+    fixed_json_obj = json.loads(resp.data[len(ufo.JSON_PREFIX):])
+    invite_url = str(fixed_json_obj['invite_code'])
 
     self.assertIn(user.INVITE_CODE_URL_PREFIX, invite_url)
     invite_code_base64 = invite_url[len(user.INVITE_CODE_URL_PREFIX):]
@@ -317,7 +319,7 @@ class UserTest(base_test.BaseTest):
     get_data = {'user_id': created_user.id}
     resp = self.client.get(flask.url_for('user_get_invite_code'),
                            query_string=get_data)
-    invite_code = json.loads(resp.data)['invite_code']
+    invite_code = json.loads(resp.data[len(ufo.JSON_PREFIX):])['invite_code']
 
     self.assertFalse(invite_code)
 

--- a/ufo/handlers/user_test.py
+++ b/ufo/handlers/user_test.py
@@ -67,7 +67,7 @@ class UserTest(base_test.BaseTest):
       users.append(user)
 
     resp = self.client.get(flask.url_for('user_list'))
-    user_list_output = json.loads(resp.data[len(ufo.JSON_PREFIX):])['items']
+    user_list_output = json.loads(resp.data[len(ufo.XSSI_PREFIX):])['items']
 
     self.assertEquals(len(user_list_output),
                       len(base_test.FAKE_EMAILS_AND_NAMES))
@@ -95,7 +95,7 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user'))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
+    json_output = json.loads(args[0][len(ufo.XSSI_PREFIX):])
     self.assertEquals([], json_output['directory_users'])
     self.assertIsNotNone(json_output['error'])
     self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
@@ -113,7 +113,7 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user'))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
+    json_output = json.loads(args[0][len(ufo.XSSI_PREFIX):])
     self.assertEquals([], json_output['directory_users'])
     self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
 
@@ -135,7 +135,7 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user', group_key=group_key))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
+    json_output = json.loads(args[0][len(ufo.XSSI_PREFIX):])
     self.assertEquals(FAKE_USERS_FOR_DISPLAY_ARRAY,
                       json_output['directory_users'])
     self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
@@ -158,7 +158,7 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user', user_key=user_key))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
+    json_output = json.loads(args[0][len(ufo.XSSI_PREFIX):])
     self.assertEquals(FAKE_USERS_FOR_DISPLAY_ARRAY,
                       json_output['directory_users'])
     self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
@@ -179,7 +179,7 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user', get_all=True))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
+    json_output = json.loads(args[0][len(ufo.XSSI_PREFIX):])
     self.assertEquals(FAKE_USERS_FOR_DISPLAY_ARRAY,
                       json_output['directory_users'])
     self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
@@ -208,7 +208,7 @@ class UserTest(base_test.BaseTest):
     response = self.client.get(flask.url_for('add_user'))
 
     args, kwargs = mock_response.call_args
-    json_output = json.loads(args[0][len(ufo.JSON_PREFIX):])
+    json_output = json.loads(args[0][len(ufo.XSSI_PREFIX):])
     self.assertEquals([], json_output['directory_users'])
     self.assertEquals(str(fake_error), json_output['error'])
     self.assertEquals(ufo.JSON_HEADERS, kwargs['headers'])
@@ -297,7 +297,7 @@ class UserTest(base_test.BaseTest):
     get_data = {'user_id': created_user.id}
     resp = self.client.get(flask.url_for('user_get_invite_code'),
                            query_string=get_data)
-    fixed_json_obj = json.loads(resp.data[len(ufo.JSON_PREFIX):])
+    fixed_json_obj = json.loads(resp.data[len(ufo.XSSI_PREFIX):])
     invite_url = str(fixed_json_obj['invite_code'])
 
     self.assertIn(user.INVITE_CODE_URL_PREFIX, invite_url)
@@ -319,7 +319,7 @@ class UserTest(base_test.BaseTest):
     get_data = {'user_id': created_user.id}
     resp = self.client.get(flask.url_for('user_get_invite_code'),
                            query_string=get_data)
-    invite_code = json.loads(resp.data[len(ufo.JSON_PREFIX):])['invite_code']
+    invite_code = json.loads(resp.data[len(ufo.XSSI_PREFIX):])['invite_code']
 
     self.assertFalse(invite_code)
 

--- a/ufo/services/error_handler.py
+++ b/ufo/services/error_handler.py
@@ -5,11 +5,13 @@ https://goo.gl/OWOa70
 
 One difference here is that we will aim to handle custom exceptions.
 """
+import json
 import logging
 
 import flask
 from werkzeug import exceptions
 
+import ufo
 from ufo.handlers import auth
 
 def handle_error(error):
@@ -31,8 +33,9 @@ def handle_error(error):
   if error.code == 404:
     return flask.render_template('error.html', error=error)
 
-  return flask.jsonify({'code': error.code,
-                        'message': error.description}), error.code
+  error_dict = {'code': error.code, 'message': error.description}
+  return flask.Response(ufo.JSON_PREFIX + json.dumps((error_dict)),
+                        headers=ufo.JSON_HEADERS)
 
 def handle_not_logged_in(error):
   """A handler to gracefully handle the not logged in error.

--- a/ufo/services/error_handler.py
+++ b/ufo/services/error_handler.py
@@ -34,7 +34,7 @@ def handle_error(error):
     return flask.render_template('error.html', error=error)
 
   error_dict = {'code': error.code, 'message': error.description}
-  resp = flask.Response(ufo.JSON_PREFIX + json.dumps((error_dict)),
+  resp = flask.Response(ufo.XSSI_PREFIX + json.dumps((error_dict)),
                         headers=ufo.JSON_HEADERS)
   resp.status_code = error.code
   return resp

--- a/ufo/services/error_handler.py
+++ b/ufo/services/error_handler.py
@@ -34,8 +34,10 @@ def handle_error(error):
     return flask.render_template('error.html', error=error)
 
   error_dict = {'code': error.code, 'message': error.description}
-  return flask.Response(ufo.JSON_PREFIX + json.dumps((error_dict)),
+  resp = flask.Response(ufo.JSON_PREFIX + json.dumps((error_dict)),
                         headers=ufo.JSON_HEADERS)
+  resp.status_code = error.code
+  return resp
 
 def handle_not_logged_in(error):
   """A handler to gracefully handle the not logged in error.

--- a/ufo/services/error_handler_test.py
+++ b/ufo/services/error_handler_test.py
@@ -1,8 +1,10 @@
 import flask
+import json
 from mock import MagicMock
 from mock import patch
 from werkzeug import exceptions
 
+import ufo
 from ufo import base_test
 from ufo.services import error_handler
 from ufo.services.custom_exceptions import SetupNeeded
@@ -38,10 +40,10 @@ class ErrorHandlerTest(base_test.BaseTest):
     """Test error handler can process HTTP error."""
     error_500 = exceptions.InternalServerError()
     resp = error_handler.handle_error(error_500)
+    resp_obj = json.loads(resp.data[len(ufo.JSON_PREFIX):])
 
-    self.assertEqual(error_500.code, resp[1])
-    self.assertTrue(str(error_500.code) in resp[0].data)
-    self.assertTrue(error_500.message in resp[0].data)
+    self.assertEqual(error_500.code, resp_obj['code'])
+    self.assertEqual(error_500.description, resp_obj['message'])
 
   def ErrorHandlerCanProcessCustomError(self):
     """Test error handler can process custom error."""

--- a/ufo/services/error_handler_test.py
+++ b/ufo/services/error_handler_test.py
@@ -40,7 +40,7 @@ class ErrorHandlerTest(base_test.BaseTest):
     """Test error handler can process HTTP error."""
     error_500 = exceptions.InternalServerError()
     resp = error_handler.handle_error(error_500)
-    resp_obj = json.loads(resp.data[len(ufo.JSON_PREFIX):])
+    resp_obj = json.loads(resp.data[len(ufo.XSSI_PREFIX):])
 
     self.assertEqual(error_500.code, resp_obj['code'])
     self.assertEqual(error_500.description, resp_obj['message'])

--- a/ufo/services/resource_provider.py
+++ b/ufo/services/resource_provider.py
@@ -46,6 +46,7 @@ def _get_landing_resources():
     'removeAdminInstructions': 'Select an Admin below by email to remove.',
     'removeAdminSubmitText': 'Remove Admin',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
+    'jsonPrefix': ufo.JSON_PREFIX,
   }
 
 def _get_login_resources():
@@ -61,6 +62,7 @@ def _get_login_resources():
     'passwordLabel': 'Password',
     'loginText': 'Login',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
+    'jsonPrefix': ufo.JSON_PREFIX,
   }
 
 def _get_oauth_resources():
@@ -102,6 +104,7 @@ def _get_oauth_resources():
     'adminEmailLabel': 'Admin Email',
     'adminPasswordlabel': 'Admin Password',
     'submitButtonText': 'Submit',
+    'jsonPrefix': ufo.JSON_PREFIX,
   }
 
 def _get_policy_resources():
@@ -136,6 +139,7 @@ def _get_policy_resources():
         'file you just downloaded. You may have to click override to edit '
         'Force Installation or Configure\'s values. Finally, click Save.'),
     'downloadText': 'Download',
+    'jsonPrefix': ufo.JSON_PREFIX,
   }
 
 
@@ -175,6 +179,7 @@ def _get_proxy_server_resources():
     'dismissText': 'Cancel',
     'confirmText': 'Add Server',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
+    'jsonPrefix': ufo.JSON_PREFIX,
     'textAreaMaxRows': 10,
     'ipLabel': 'IP Address',
     'nameLabel': 'Server Name',
@@ -215,6 +220,7 @@ def _get_settings_resources():
     'proxyValidityText': 'Enforce Proxy Server Check from Invitation Link',
     'networkJailText': 'Enforce Network Jail Before Google Login',
     'saveText': 'Save',
+    'jsonPrefix': ufo.JSON_PREFIX,
   }
 
 def _get_user_resources():
@@ -261,6 +267,7 @@ def _get_user_resources():
     'modalId': 'userModal',
     'dismissText': 'Cancel',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
+    'jsonPrefix': ufo.JSON_PREFIX,
     'addFlowTextDicts': [
         {
           'id': 'groupAdd',

--- a/ufo/services/resource_provider.py
+++ b/ufo/services/resource_provider.py
@@ -46,7 +46,7 @@ def _get_landing_resources():
     'removeAdminInstructions': 'Select an Admin below by email to remove.',
     'removeAdminSubmitText': 'Remove Admin',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.JSON_PREFIX,
+    'jsonPrefix': ufo.XSSI_PREFIX,
   }
 
 def _get_login_resources():
@@ -62,7 +62,7 @@ def _get_login_resources():
     'passwordLabel': 'Password',
     'loginText': 'Login',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.JSON_PREFIX,
+    'jsonPrefix': ufo.XSSI_PREFIX,
   }
 
 def _get_oauth_resources():
@@ -104,7 +104,7 @@ def _get_oauth_resources():
     'adminEmailLabel': 'Admin Email',
     'adminPasswordlabel': 'Admin Password',
     'submitButtonText': 'Submit',
-    'jsonPrefix': ufo.JSON_PREFIX,
+    'jsonPrefix': ufo.XSSI_PREFIX,
   }
 
 def _get_policy_resources():
@@ -139,7 +139,7 @@ def _get_policy_resources():
         'file you just downloaded. You may have to click override to edit '
         'Force Installation or Configure\'s values. Finally, click Save.'),
     'downloadText': 'Download',
-    'jsonPrefix': ufo.JSON_PREFIX,
+    'jsonPrefix': ufo.XSSI_PREFIX,
   }
 
 
@@ -179,7 +179,7 @@ def _get_proxy_server_resources():
     'dismissText': 'Cancel',
     'confirmText': 'Add Server',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.JSON_PREFIX,
+    'jsonPrefix': ufo.XSSI_PREFIX,
     'textAreaMaxRows': 10,
     'ipLabel': 'IP Address',
     'nameLabel': 'Server Name',
@@ -220,7 +220,7 @@ def _get_settings_resources():
     'proxyValidityText': 'Enforce Proxy Server Check from Invitation Link',
     'networkJailText': 'Enforce Network Jail Before Google Login',
     'saveText': 'Save',
-    'jsonPrefix': ufo.JSON_PREFIX,
+    'jsonPrefix': ufo.XSSI_PREFIX,
   }
 
 def _get_user_resources():
@@ -267,7 +267,7 @@ def _get_user_resources():
     'modalId': 'userModal',
     'dismissText': 'Cancel',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.JSON_PREFIX,
+    'jsonPrefix': ufo.XSSI_PREFIX,
     'addFlowTextDicts': [
         {
           'id': 'groupAdd',

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -85,7 +85,7 @@
         <paper-button class="editElements hideElement anchor-button" on-tap="submitEditForm" id="serverEditSubmitButton">
         <strong>{{resources.saveText}}</strong>
         </paper-button>
-        <form is="iron-form" method="post" action="{{resources.deleteUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
+        <form is="iron-form" id="serverDeleteForm" method="post" action="{{resources.deleteUrl}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
           <input type="hidden" name="server_id" value="{{item.id}}">
           <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
           <paper-button on-tap="submitForm" class="delete-button" id="serverDeleteButton" type="submit">
@@ -109,10 +109,6 @@
           type: Object,
           notify: true,
         },
-        ajaxResponse: {
-          type: Object,
-          notify: true,
-        },
         loading: {
           type: Boolean,
           value: false,
@@ -122,8 +118,11 @@
           type: Object,
         },
       },
-      setAjaxResponse: function(response) {
-        this.set('ajaxResponse', response);
+      ready: function() {
+        this.$.serverEditForm.request.handleAs = "json";
+        this.$.serverEditForm.request.jsonPrefix = this.resources.jsonPrefix;
+        this.$.serverDeleteForm.request.handleAs = "json";
+        this.$.serverDeleteForm.request.jsonPrefix = this.resources.jsonPrefix;
       },
       enableSpinner: function() {
         this.set('loading', true);
@@ -131,7 +130,7 @@
       getXsrfToken: function() {
         return document.getElementById('globalXsrf').value;
       },
-      submitForm: function(e, details) {
+      submitForm: function(e, detail) {
         var elem = e.target;
         while (elem.tagName.toLowerCase() != 'form') {
           elem = elem.parentElement;
@@ -144,17 +143,17 @@
         }
         elem.submit();
       },
-      submitEditForm: function(e, details) {
+      submitEditForm: function(e, detail) {
         this.$.serverEditForm.submit();
       },
-      parseEditResponse: function(e, details) {
-        this.sendJsonToList(details.xhr.response);
+      parseEditResponse: function(e, detail) {
+        this.sendJsonToList(this.$.serverEditForm.request.lastResponse);
         this.set('loading', false);
         this.set('oldItem', this.item);
         this.showHideEdit(true);
       },
-      parseDeleteResponse: function(e, details) {
-        this.sendJsonToList(details.xhr.response);
+      parseDeleteResponse: function(e, detail) {
+        this.sendJsonToList(this.$.serverDeleteForm.request.lastResponse);
         this.set('loading', false);
         this.closeDialog();
       },
@@ -176,11 +175,11 @@
         this.openDialog();
         this.switchToServerEdit();
       },
-      switchToServerEdit: function(e, details) {
+      switchToServerEdit: function(e, detail) {
         this.set('oldItem', this.item);
         this.showHideEdit(false);
       },
-      cancelServerEdit: function(e, details) {
+      cancelServerEdit: function(e, detail) {
         this.resetInputs();
         this.showHideEdit(true);
       },

--- a/ufo/static/errorNotification.html
+++ b/ufo/static/errorNotification.html
@@ -98,6 +98,7 @@
         'ApplicationError': 'showErrorNotification',
       },
       showErrorNotification: function(event, detail) {
+        console.log(detail);
         this.errorCode = detail.code;
         this.errorMessage = detail.message;
         this.$.errorNotificationDialog.open();

--- a/ufo/static/errorNotification.html
+++ b/ufo/static/errorNotification.html
@@ -98,7 +98,6 @@
         'ApplicationError': 'showErrorNotification',
       },
       showErrorNotification: function(event, detail) {
-        console.log(detail);
         this.errorCode = detail.code;
         this.errorMessage = detail.message;
         this.$.errorNotificationDialog.open();

--- a/ufo/static/listItems.html
+++ b/ufo/static/listItems.html
@@ -47,7 +47,8 @@
       handle-as="json"
       id="getItemsAjax"
       loading="{{loading}}"
-      last-response="{{ajaxResponse}}">
+      last-response="{{ajaxResponse}}"
+      json-prefix="{{resources.jsonPrefix}}">
     </iron-ajax>
     <paper-listbox>
       <paper-icon-item id="columnHeader" class="horizontal layout">
@@ -175,6 +176,8 @@
         var name = 'form';
         var elem = this._findAncestorMatchingTagnameFromTarget(e.target, name);
         if (elem) {
+          elem.request.handleAs = "json";
+          elem.request.jsonPrefix = this.resources.jsonPrefix;
           elem.submit();
         }
       },

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -61,6 +61,10 @@
       listeners: {
         'iron-form-error': 'handleFormError',
       },
+      ready: function() {
+        this.$.serverAddForm.request.handleAs = "json";
+        this.$.serverAddForm.request.jsonPrefix = this.resources.jsonPrefix;
+      },
       enableSpinner: function() {
         this.set('loading', true);
       },
@@ -83,7 +87,7 @@
         this.closeModal();
       },
       parsePostResponse: function(e, detail) {
-        this.sendServersJsonToList(detail.xhr.response);
+        this.sendServersJsonToList(this.$.serverAddForm.request.lastResponse);
         this.closeModal();
       },
       sendServersJsonToList: function(updatedServersJson) {

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -81,7 +81,15 @@
         }
       },
       handleFormError: function(event, detail) {
-        var errorDetail = {'detail': detail.request.xhr.response};
+        event.stopPropagation();
+        var fixedJsonText = detail.request.xhr.response;
+        var prefixIndex = fixedJsonText.indexOf(this.resources.jsonPrefix);
+        if (prefixIndex >= 0) {
+          var position = prefixIndex + this.resources.jsonPrefix.length;
+          fixedJsonText = fixedJsonText.substring(position);
+        }
+        var jsonObj = JSON.parse(fixedJsonText);
+        var errorDetail = {'detail': jsonObj};
         var errorEvent = new CustomEvent('ApplicationError', errorDetail);
         document.getElementById('error-notification').dispatchEvent(errorEvent);
         this.closeModal();

--- a/ufo/static/settingsConfiguration.html
+++ b/ufo/static/settingsConfiguration.html
@@ -5,7 +5,7 @@
 
 <dom-module id="settings-configuration">
   <style is="custom-style">
-    #policy-config-form {
+    #policyConfigForm {
       margin-left: 40px;
       margin-right: 25px;
       margin-bottom: 25px;
@@ -18,9 +18,10 @@
       handle-as="json"
       id="getSettingsAjax"
       loading="{{loading}}"
-      last-response="{{ajaxResponse}}">
+      last-response="{{ajaxResponse}}"
+      json-prefix="{{resources.jsonPrefix}}">
     </iron-ajax>
-    <form is="iron-form" id="policy-config-form" method="post" action="{{resources.editUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseConfigResponse">
+    <form is="iron-form" id="policyConfigForm" method="post" action="{{resources.editUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseConfigResponse">
       <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="{{resources.proxyValidityText}}" checked$={{ajaxResponse.enforce_proxy_server_validity}}></ufo-toggle-input>
       <br>
       <ufo-toggle-input input-name="enforce_network_jail" button-text="{{resources.networkJailText}}" checked$={{ajaxResponse.enforce_network_jail}}></ufo-toggle-input>
@@ -30,7 +31,7 @@
         <template is="dom-if" if="{{loading}}">
           <paper-spinner id="settingsSpinner" active$={{loading}}></paper-spinner>
         </template>
-        <paper-button class="anchor-button" id="saveSettingsButton" onclick="submitByFormId('policy-config-form')" type="submit">
+        <paper-button class="anchor-button" id="saveSettingsButton" onclick="submitByFormId('policyConfigForm')" type="submit">
           <strong>{{resources.saveText}}</strong>
         </paper-button>
       </div>
@@ -53,6 +54,10 @@
           notify: true,
         },
       },
+      ready: function() {
+        this.$.policyConfigForm.request.handleAs = "json";
+        this.$.policyConfigForm.request.jsonPrefix = this.resources.jsonPrefix;
+      },
       enableSpinner: function() {
         this.set('loading', true);
       },
@@ -60,7 +65,7 @@
         return document.getElementById('globalXsrf').value;
       },
       parseConfigResponse: function(e, details) {
-        this.set('ajaxResponse', details.xhr.response);
+        this.set('ajaxResponse', this.$.policyConfigForm.request.lastResponse);
         this.set('loading', false);
       },
     });

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -249,7 +249,15 @@
         }
       },
       handleFormError: function(event, detail) {
-        var errorDetail = {'detail': detail.request.xhr.response};
+        event.stopPropagation();
+        var fixedJsonText = detail.request.xhr.response;
+        var prefixIndex = fixedJsonText.indexOf(this.resources.jsonPrefix);
+        if (prefixIndex >= 0) {
+          var position = prefixIndex + this.resources.jsonPrefix.length;
+          fixedJsonText = fixedJsonText.substring(position);
+        }
+        var jsonObj = JSON.parse(fixedJsonText);
+        var errorDetail = {'detail': jsonObj};
         var errorEvent = new CustomEvent('ApplicationError', errorDetail);
         document.getElementById('error-notification').dispatchEvent(errorEvent);
         this.closeAdminDialog();

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -37,7 +37,8 @@
       handle-as="json"
       id="getAdminsAjax"
       loading="{{loading}}"
-      last-response="{{ajaxResponse}}">
+      last-response="{{ajaxResponse}}"
+      json-prefix="{{resources.jsonPrefix}}">
     </iron-ajax>
 
     <paper-dialog class="dropdown-content" id="ufoDropdownMenu" with-backdrop>
@@ -188,6 +189,14 @@
       listeners: {
         'iron-form-error': 'handleFormError',
       },
+      ready: function() {
+        this.$.addAdminForm.request.handleAs = "json";
+        this.$.addAdminForm.request.jsonPrefix = this.resources.jsonPrefix;
+        this.$.changeAdminPasswordForm.request.handleAs = "json";
+        this.$.changeAdminPasswordForm.request.jsonPrefix = this.resources.jsonPrefix;
+        this.$.removeAdminForm.request.handleAs = "json";
+        this.$.removeAdminForm.request.jsonPrefix = this.resources.jsonPrefix;
+      },
       getXsrfToken: function() {
         return document.getElementById('globalXsrf').value;
       },
@@ -308,13 +317,13 @@
       },
       parseAddAdminResponse: function(e, details) {
         var email = this.querySelector('#paperAdminEmail').value;
-        var admins = details.xhr.response.items;
+        var admins = this.$.addAdminForm.request.lastResponse.items;
         if (admins) {
           var found = this._findEmailInAdminList(admins, email);
           if (found) {
             this.set('showResponseStatus', true);
             this.set('responseStatus', this.resources.adminAddSuccessText);
-            this.set('ajaxResponse', details.xhr.response);
+            this.set('ajaxResponse', this.$.addAdminForm.request.lastResponse);
             this.resetAddAdminForm();
           } else {
             this.set('showResponseStatus', true);
@@ -327,12 +336,12 @@
         this.set('loading', false);
       },
       parseChangeAdminPasswordResponse: function(e, details) {
-        this.set('ajaxResponse', details.xhr.response);
+        this.set('ajaxResponse', this.$.changeAdminPasswordForm.request.lastResponse);
         this.set('loading', false);
         this.resetChangeAdminPasswordForm();
       },
       parseRemoveAdminResponse: function(e, details) {
-        this.set('ajaxResponse', details.xhr.response);
+        this.set('ajaxResponse', this.$.removeAdminForm.request.lastResponse);
         this.set('loading', false);
         this.resetRemoveAdminForm();
       },

--- a/ufo/static/ufoSearchBar.html
+++ b/ufo/static/ufoSearchBar.html
@@ -23,7 +23,7 @@
   </style>
   <template>
     <div class="middle horizontal layout center flex">
-      <form is="iron-form" method="GET" action="{{searchResources.searchJsonUrl}}" loading="{{loading}}" last-response="{{searchJson}}" on-iron-form-presubmit="presubmit" on-iron-form-response="parseSearchResponse" id="searchForm" content-type="application/json" class="flex">
+      <form is="iron-form" method="GET" action="{{searchResources.searchJsonUrl}}" on-iron-form-presubmit="presubmit" on-iron-form-response="parseSearchResponse" id="searchForm" content-type="application/json" class="flex">
         <paper-input id="searchBar" no-label-float name="search_input" value="{{searchText}}">
           <paper-icon-button id="searchButton" icon="search" prefix on-tap="submitForm"></paper-icon-button>
           <paper-icon-button icon="arrow-back" suffix id="suffix" class="hideSuffix" on-tap="resetLists"></paper-icon-button>
@@ -63,6 +63,10 @@
           notify: true,
         },
       },
+      ready: function() {
+        this.$.searchForm.request.handleAs = "json";
+        this.$.searchForm.request.jsonPrefix = this.searchResources.jsonPrefix;
+      },
       presubmit: function() {
         var userList = document.getElementById(this.userResources.listId);
         var serverList = document.getElementById(
@@ -90,7 +94,7 @@
         elem.submit();
       },
       parseSearchResponse: function(e, details) {
-        var searchJson = details.xhr.response;
+        var searchJson = this.$.searchForm.request.lastResponse;
         if (searchJson.users) {
           this.sendJsonToList(searchJson.users, this.userResources.listId);
         }

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -164,7 +164,6 @@
         }
       },
       parsePostResponse: function(e, detail) {
-        console.log(e.target.request.lastResponse);
         this.sendUsersJsonToList(e.target.request.lastResponse);
         this.resetForms();
         this.closeModal();

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -164,12 +164,21 @@
         }
       },
       parsePostResponse: function(e, detail) {
+        console.log(e.target.request.lastResponse);
         this.sendUsersJsonToList(e.target.request.lastResponse);
         this.resetForms();
         this.closeModal();
       },
       handleFormError: function(event, detail) {
-        var errorDetail = {'detail': detail.request.xhr.response};
+        event.stopPropagation();
+        var fixedJsonText = detail.request.xhr.response;
+        var prefixIndex = fixedJsonText.indexOf(this.resources.jsonPrefix);
+        if (prefixIndex >= 0) {
+          var position = prefixIndex + this.resources.jsonPrefix.length;
+          fixedJsonText = fixedJsonText.substring(position);
+        }
+        var jsonObj = JSON.parse(fixedJsonText);
+        var errorDetail = {'detail': jsonObj};
         var errorEvent = new CustomEvent('ApplicationError', errorDetail);
         document.getElementById('error-notification').dispatchEvent(errorEvent);
         this.closeModal();

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -18,7 +18,7 @@
         <paper-spinner id="spinner" class="absolutePositionSpinner" active$={{loading}}></paper-spinner>
       </template>
       <template is="dom-if" if="{{showInputFields}}">
-        <form is="iron-form" id="{{addFlowTextObj.id}}" method="get" action="{{resources.addUrl}}" on-iron-form-response="parseGetResponse" on-iron-form-presubmit="enableSpinner">
+        <form is="iron-form" id="{{addFlowTextObj.id}}" method="get" action="{{resources.addUrl}}" on-iron-form-response="parseGetResponse" on-iron-form-presubmit="enableSpinnerAndSetPrefixes">
           <template is="dom-if" if="[[!idMatches(addFlowTextObj.id, 'domainAdd')]]">
             <paper-input label="{{addFlowTextObj.label1}}" type="textbox" name="{{addFlowTextObj.name1}}" pattern="{{resources.regexes.keyLookupPattern}}" error-message="{{resources.regexes.keyLookupError}}"></paper-input>
             <br>
@@ -130,17 +130,28 @@
       listeners: {
         'iron-form-error': 'handleFormError',
       },
+      setJsonPrefixes: function() {
+        var addForm = document.getElementById(this.addFlowTextObj.id);
+        addForm.request.handleAs = "json";
+        addForm.request.jsonPrefix = this.resources.jsonPrefix;
+      },
       enableSpinner: function() {
         this.set('loading', true);
+      },
+      enableSpinnerAndSetPrefixes: function() {
+        this.setJsonPrefixes();
+        this.enableSpinner();
       },
       submitGetForm: function() {
         this.querySelector('#' + this.addFlowTextObj.id).submit();
       },
       submitPostForm: function() {
+        this.querySelector('#addPostForm').request.handleAs = "json";
+        this.querySelector('#addPostForm').request.jsonPrefix = this.resources.jsonPrefix;
         this.setSelectedUsersFromCheckboxes();
         this.querySelector('#addPostForm').submit();
       },
-      parseGetResponse: function(e, details) {
+      parseGetResponse: function(e, detail) {
         this.set('lastResponse', e.target.request.lastResponse);
         this.set('showInputFields', false);
         this.set('loading', false);
@@ -152,8 +163,8 @@
           userModal.close();
         }
       },
-      parsePostResponse: function(e, details) {
-        this.sendUsersJsonToList(details.xhr.response);
+      parsePostResponse: function(e, detail) {
+        this.sendUsersJsonToList(e.target.request.lastResponse);
         this.resetForms();
         this.closeModal();
       },
@@ -163,7 +174,7 @@
         document.getElementById('error-notification').dispatchEvent(errorEvent);
         this.closeModal();
       },
-      resetForms: function(e, details) {
+      resetForms: function(e, detail) {
         this.set('showInputFields', true);
         document.getElementById(this.addFlowTextObj.id).reset();
         var addPostForm = this.querySelector('#addPostForm');

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -133,7 +133,15 @@
         this.closeModal();
       },
       handleFormError: function(event, detail) {
-        var errorDetail = {'detail': detail.request.xhr.response};
+        event.stopPropagation();
+        var fixedJsonText = detail.request.xhr.response;
+        var prefixIndex = fixedJsonText.indexOf(this.resources.jsonPrefix);
+        if (prefixIndex >= 0) {
+          var position = prefixIndex + this.resources.jsonPrefix.length;
+          fixedJsonText = fixedJsonText.substring(position);
+        }
+        var jsonObj = JSON.parse(fixedJsonText);
+        var errorDetail = {'detail': jsonObj};
         var errorEvent = new CustomEvent('ApplicationError', errorDetail);
         document.getElementById('error-notification').dispatchEvent(errorEvent);
         this.closeModal();

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -94,6 +94,15 @@
       listeners: {
         'iron-form-error': 'handleFormError',
       },
+      setJsonPrefixes: function() {
+        var i = 0;
+        for (; i < this.resources.addFlowTextDicts.length; i++) {
+          var elementId = this.resources.addFlowTextDicts[i].id;
+          var addForm = document.getElementById(elementId);
+          addForm.request.handleAs = "json";
+          addForm.request.jsonPrefix = this.resources.jsonPrefix;
+        }
+      },
       enableSpinner: function() {
         this.set('loading', true);
       },
@@ -107,11 +116,10 @@
         input.value = JSON.stringify(userArray);
       },
       submitPostForm: function() {
+        this.setJsonPrefixes();
         this.makeManualInputsJsonArray();
         this.querySelector('#manualAdd').submit();
       },
-
-
       closeModal: function() {
         this.set('loading', false);
         var userModal = document.getElementById('userModal');
@@ -120,7 +128,7 @@
         }
       },
       parsePostResponse: function(e, detail) {
-        this.sendUsersJsonToList(detail.xhr.response);
+        this.sendUsersJsonToList(e.target.request.lastResponse);
         this.resetForm();
         this.closeModal();
       },

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -47,7 +47,7 @@
     <template is="dom-if" if="{{loading}}">
       <paper-spinner id="userDetailsSpinner" class="fixedPositionSpinner" active$={{loading}}></paper-spinner>
     </template>
-    <form is="iron-form" method="GET" action="{{resources.inviteCodeUrl}}" loading="{{loading}}" last-response="{{inviteCodeJson}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseInviteCodeResponse" hidden id="getInviteCodeAjax" on-iron-form-error="inviteCodeErrorResponse">
+    <form is="iron-form" method="GET" action="{{resources.inviteCodeUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseInviteCodeResponse" hidden id="getInviteCodeAjax" on-iron-form-error="inviteCodeErrorResponse">
       <input type="hidden" name="user_id" value="{{item.id}}">
     </form>
     <paper-dialog id="{{resources.detailsOverlayId}}" with-backdrop>
@@ -56,7 +56,7 @@
           <iron-icon src="{{resources.itemIconUrl}}" item-icon></iron-icon>
           <div class="first-div"><strong>{{item.name}}</strong></div>
           <div class="second-div">{{item.email}}</div>
-          <form is="iron-form" method="post" action="{{resources.revokeToggleUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" class="third-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
+          <form is="iron-form" id="userDisableEnableForm" method="post" action="{{resources.revokeToggleUrl}}" class="third-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
             <input type="hidden" name="user_id" value="{{item.id}}">
             <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
             <paper-button on-tap="submitForm" class="topLineButton" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>
@@ -79,7 +79,7 @@
           <paper-button on-tap="copyInviteCode" class="anchor-button" id="copyInviteCodeButton" type="submit">
             <iron-icon icon="content-copy"></iron-icon> <strong>{{resources.copyLabel}}</strong>
           </paper-button>
-          <form is="iron-form" method="post" action="{{resources.rotateKeysUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseRotateResponse" on-iron-form-presubmit="enableSpinner">
+          <form is="iron-form" id="rotateKeysForm" method="post" action="{{resources.rotateKeysUrl}}" on-iron-form-response="parseRotateResponse" on-iron-form-presubmit="setRotateKeysAndEnable">
             <input type="hidden" name="user_id" value="{{item.id}}">
             <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
             <paper-button on-tap="submitForm" class="anchor-button" id="rotateKeysButton" type="submit">
@@ -87,7 +87,7 @@
             </paper-button>
           </form>
         </template>
-        <form is="iron-form" method="post" action="{{resources.deleteUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
+        <form is="iron-form" id="userDeleteForm" method="post" action="{{resources.deleteUrl}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
           <input type="hidden" name="user_id" value="{{item.id}}">
           <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
           <paper-button on-tap="submitForm" class="delete-button" id="userDeleteButton" type="submit">
@@ -111,10 +111,6 @@
           type: Object,
           notify: true,
         },
-        ajaxResponse: {
-          type: Object,
-          notify: true,
-        },
         loading: {
           type: Boolean,
           value: false,
@@ -126,8 +122,23 @@
           notify: true,
         },
       },
-      setAjaxResponse: function(response) {
-        this.set('ajaxResponse', response);
+      ready: function() {
+        this.$.getInviteCodeAjax.request.handleAs = "json";
+        this.$.getInviteCodeAjax.request.jsonPrefix = this.resources
+          .jsonPrefix;
+        this.$.userDisableEnableForm.request.handleAs = "json";
+        this.$.userDisableEnableForm.request.jsonPrefix = this.resources
+          .jsonPrefix;
+        this.$.userDeleteForm.request.handleAs = "json";
+        this.$.userDeleteForm.request.jsonPrefix = this.resources.jsonPrefix;
+      },
+      setRotateKeysAndEnable: function() {
+        this.setRotateKeysJsonPrefix();
+        this.enableSpinner();
+      },
+      setRotateKeysJsonPrefix: function() {
+        this.querySelector('#rotateKeysForm').request.handleAs = "json";
+        this.querySelector('#rotateKeysForm').request.jsonPrefix = this.resources.jsonPrefix;
       },
       enableSpinner: function() {
         this.set('loading', true);
@@ -138,7 +149,7 @@
       getXsrfToken: function() {
         return document.getElementById('globalXsrf').value;
       },
-      submitForm: function(e, details) {
+      submitForm: function(e, detail) {
         var elem = e.target;
         while (elem.tagName.toLowerCase() != 'form') {
           elem = elem.parentElement;
@@ -151,19 +162,19 @@
         }
         elem.submit();
       },
-      parseRevokeResponse: function(e, details) {
-        this.sendUsersJsonToList(details.xhr.response);
+      parseRevokeResponse: function(e, detail) {
+        this.sendUsersJsonToList(this.$.userDisableEnableForm.request.lastResponse);
       },
-      parseRotateResponse: function(e, details) {
-        this.sendUsersJsonToList(details.xhr.response);
+      parseRotateResponse: function(e, detail) {
+        this.sendUsersJsonToList(e.target.request.lastResponse);
         this.getUpdatedInviteCode();
       },
-      parseDeleteResponse: function(e, details) {
-        this.sendUsersJsonToList(details.xhr.response);
+      parseDeleteResponse: function(e, detail) {
+        this.sendUsersJsonToList(this.$.userDeleteForm.request.lastResponse);
         this.closeDialog();
       },
-      parseInviteCodeResponse: function(e, details) {
-        this.set('inviteCodeJson', details.xhr.response);
+      parseInviteCodeResponse: function(e, detail) {
+        this.set('inviteCodeJson', this.$.getInviteCodeAjax.request.lastResponse);
         this.set('loading', false);
       },
       sendUsersJsonToList: function(updatedUsersJson) {
@@ -192,7 +203,7 @@
         document.execCommand('copy');
       },
       getUpdatedInviteCode: function() {
-        this.$.getInviteCodeAjax.submit()
+        this.$.getInviteCodeAjax.submit();
       },
     });
   </script>


### PR DESCRIPTION
The changes here were to add the requested content type and charset to the JSON responses along with a prefix to mitigate XSS. Each change ended up being fairly small in terms of lines, but they had to be copy and pasted across several different places.

Each JSON handler needed to add the prefix and headers as necessary. The prefix then has to be stripped in the frontend when parsing. To remove it, iron-ajax elements actually have a specific property that can be set to automatically strip the prefix. Iron-form elements contain an iron-ajax element (under the form's request property), so they can be set similarly. Doing this for dynamically generated forms is a little more tricky, but I've managed to work it out.

The other changes were to update the unit tests to account for the JSON prefix when checking responses. The functional tests all passed when rerunning them without any modifications, but feel free to check on your own as necessary.

Finally, the change to the error handler was more in depth since it was using flask.jsonify instead of flask.response. Everywhere else uses flask.response, so I modified that and updated the associated frontend handlers since the format became slightly different. All of the JSON handlers should now function identically.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/144)

<!-- Reviewable:end -->
