### PR TITLE
Adding a Content Security Policy to the HTML Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ venv/*
 *.pyc
 ufo/static/bower_components/*
 ufo/static/vulcanized.html
+ufo/static/vulcanized.js
 node_modules/*
 chrome_driver/*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "ufo-management-server",
   "dependencies": {
     "bower": "^1.7.1",
-    "vulcanize": "1.14.8"
+    "vulcanize": "1.14.8",
+    "crisper": "2.0.2"
   },
   "scripts": {
     "postinstall": "bower install && ./vulcanize.sh"

--- a/ufo/static/setScrollableDialogToModal.html
+++ b/ufo/static/setScrollableDialogToModal.html
@@ -1,0 +1,25 @@
+
+<dom-module id="set-scrollable-dialog-to-modal">
+  <template>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'set-scrollable-dialog-to-modal',
+      attached: function() {
+        var modal = document.getElementById('userModal');
+        console.log(modal);
+        if (modal) {
+          var scrollables = modal.getElementsByTagName(
+            'paper-dialog-scrollable');
+          console.log(scrollables);
+          var otherScrollables = modal.querySelectorAll('paper-dialog-scrollable');
+          console.log(otherScrollables);
+          for (var i in scrollables) {
+            scrollables[i].dialogElement = modal;
+          }
+        }
+      },
+    });
+  </script>
+</dom-module>

--- a/ufo/static/setScrollableDialogToModal.html
+++ b/ufo/static/setScrollableDialogToModal.html
@@ -1,20 +1,19 @@
-
 <dom-module id="set-scrollable-dialog-to-modal">
   <template>
   </template>
 
   <script>
+    // This is a helper element that just sets a scrollable dialog element when
+    // attached to the page. It is used for the scrollable dialog in the user
+    // add flow, since it is not a direct descendant of the element we need it
+    // to scroll within.
     Polymer({
       is: 'set-scrollable-dialog-to-modal',
       attached: function() {
         var modal = document.getElementById('userModal');
-        console.log(modal);
         if (modal) {
           var scrollables = modal.getElementsByTagName(
             'paper-dialog-scrollable');
-          console.log(scrollables);
-          var otherScrollables = modal.querySelectorAll('paper-dialog-scrollable');
-          console.log(otherScrollables);
           for (var i in scrollables) {
             scrollables[i].dialogElement = modal;
           }

--- a/ufo/static/style.css
+++ b/ufo/static/style.css
@@ -63,12 +63,16 @@ paper-dialog {
 }
 
 paper-dialog-scrollable {
+  display: flex;
+  flex-direction: column;
   max-height: 300px;
 }
 
 paper-dialog-scrollable > div {
   max-width: none!important;
   max-height: 250px;
+  position: static!important;
+  flex: 1;
 }
 
 .title {

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -33,7 +33,7 @@
       </template>
       <template is="dom-if" if="{{!showInputFields}}">
         <template is="dom-if" if="{{shouldDisplayWithDialog}}">
-          <paper-dialog-scrollable dialog-element="">
+          <paper-dialog-scrollable>
             <form is="iron-form" id="addPostForm" method="post" action="{{resources.addUrl}}" on-iron-form-response="parsePostResponse" on-iron-form-presubmit="enableSpinner">
               <paper-listbox>
                 <template is="dom-repeat" items="[[lastResponse.directory_users]]">
@@ -132,8 +132,8 @@
         this.querySelector('#addPostForm').submit();
       },
       parseGetResponse: function(e, details) {
-        this.set('showInputFields', false);
         this.set('lastResponse', e.target.request.lastResponse);
+        this.set('showInputFields', false);
         this.set('loading', false);
       },
       closeModal: function() {

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -33,7 +33,7 @@
       </template>
       <template is="dom-if" if="{{!showInputFields}}">
         <template is="dom-if" if="{{shouldDisplayWithDialog}}">
-          <paper-dialog-scrollable>
+          <paper-dialog-scrollable dialog-element="">
             <form is="iron-form" id="addPostForm" method="post" action="{{resources.addUrl}}" on-iron-form-response="parsePostResponse" on-iron-form-presubmit="enableSpinner">
               <paper-listbox>
                 <template is="dom-repeat" items="[[lastResponse.directory_users]]">
@@ -48,16 +48,7 @@
               <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
             </form>
           </paper-dialog-scrollable>
-          <script>
-          var modal = document.getElementById('userModal');
-          if (modal) {
-            var scrollables = modal.getElementsByTagName(
-              'paper-dialog-scrollable');
-            for (var i in scrollables) {
-              scrollables[i].dialogElement = modal;
-            }
-          }
-          </script>
+          <set-scrollable-dialog-to-modal></set-scrollable-dialog-to-modal>
         </template>
         <template is="dom-if" if="{{!shouldDisplayWithDialog}}">
           <form is="iron-form" id="addPostForm" method="post" action="{{resources.addUrl}}" on-iron-form-response="parsePostResponse" on-iron-form-presubmit="enableSpinner">
@@ -141,8 +132,8 @@
         this.querySelector('#addPostForm').submit();
       },
       parseGetResponse: function(e, details) {
-        this.set('lastResponse', e.target.request.lastResponse);
         this.set('showInputFields', false);
+        this.set('lastResponse', e.target.request.lastResponse);
         this.set('loading', false);
       },
       closeModal: function() {

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <title>{% block title %}{% endblock %}</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src http:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'">
   <!-- Include web components script for Polymer to work on firefox. -->
   <script src="{{ url_for('static', filename='bower_components/webcomponentsjs/webcomponents-lite.min.js') }}"></script>
   <link rel="import" href="{{ url_for('static', filename='vulcanized.html') }}" />

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <title>{% block title %}{% endblock %}</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'">
   <!-- Include web components script for Polymer to work on firefox. -->
   <script src="{{ url_for('static', filename='bower_components/webcomponentsjs/webcomponents-lite.min.js') }}"></script>
   <link rel="import" href="{{ url_for('static', filename='vulcanized.html') }}" />

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <title>{% block title %}{% endblock %}</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src http:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'">
   <!-- Include web components script for Polymer to work on firefox. -->
   <script src="{{ url_for('static', filename='bower_components/webcomponentsjs/webcomponents-lite.min.js') }}"></script>
   <link rel="import" href="{{ url_for('static', filename='vulcanized.html') }}" />

--- a/vulcanize.sh
+++ b/vulcanize.sh
@@ -9,6 +9,7 @@ ROOT_DIR="$(cd "$(dirname $0)"; pwd)";
 STATIC_DIR="${ROOT_DIR}/ufo/static/"
 
 VULCANIZE_COMMAND="${ROOT_DIR}/node_modules/.bin/vulcanize"
+CRISPER_COMMAND="${ROOT_DIR}/node_modules/.bin/crisper"
 BOWER_COMMAND="${ROOT_DIR}/node_modules/.bin/bower"
 
 BOWER_OPTIONS="--allow-root --config.interactive=false"
@@ -16,6 +17,7 @@ BOWER_OPTIONS="--allow-root --config.interactive=false"
 TEMP_FILE_LIST="temp_file_for_vulcanize_list"
 HTML_FILE_TO_VULCANIZE="vulcanize_input.html"
 VULCANIZED_HTML_FILE="vulcanized.html"
+VULCANIZED_JS_FILE="vulcanized.js"
 
 IMPORT_BEFORE_STATEMENT='<link rel="import" href="'
 IMPORT_AFTER_STATEMENT='" />'
@@ -54,6 +56,7 @@ function findHtmlFilesToVulcanize ()
 {
   runInStaticDirAndAssertCmd "rm -fr $TEMP_FILE_LIST"
   runInStaticDirAndAssertCmd "rm -fr $HTML_FILE_TO_VULCANIZE"
+  runInStaticDirAndAssertCmd "rm -fr $VULCANIZED_HTML_FILE"
   runInStaticDirAndAssertCmd "touch $TEMP_FILE_LIST"
   # This searches through the ufo/static/ directory recursively and finds all
   # files that match *html, but excludes index.html, basic.html, and files
@@ -84,9 +87,10 @@ function createSingleHtmlFileToVulcanize ()
 function vulcanizeSingleFileForImports ()
 {
   runInStaticDirAndAssertCmd "rm -fr $VULCANIZED_HTML_FILE"
+  runInStaticDirAndAssertCmd "rm -fr $VULCANIZED_JS_FILE"
   # This finally vulcanizes all the import statements into one flat file,
   # $VULCANIZED_HTML_FILE, with comments removed and scripts inlined.
-  runInStaticDirAndAssertCmd "${VULCANIZE_COMMAND} $HTML_FILE_TO_VULCANIZE > $VULCANIZED_HTML_FILE --strip-comments --inline-scripts"
+  runInStaticDirAndAssertCmd "${VULCANIZE_COMMAND} $HTML_FILE_TO_VULCANIZE --strip-comments --inline-scripts | ${CRISPER_COMMAND} --html ${VULCANIZED_HTML_FILE} --js ${VULCANIZED_JS_FILE}"
   runInStaticDirAndAssertCmd "rm -fr $HTML_FILE_TO_VULCANIZE"
 }
 


### PR DESCRIPTION
This change went a little bit down the rabbit hole, so here's the explanation for all the additional stuff beyond the actual CSP tag.

In order to limit our CSP to not allow unsafe-inline with scripts, we needed to load our JS separate from our HTML. Since our HTML gets pulled into the DOM via imports, the vulcanized JS looks like it is all inline scripts. To move these out to a file, we could simply leave them in their unvulcanized form, but that's not very clean and removes all the benefits from vulcanization. Instead, we can use a tool called crisper that allows us to have a separate vulcanized JS file in addition to our HTML. All the JS now lives in that file, and the vulcanized HTML file calls to load that script, so we don't even have to add a new import manually.

In order to actually use crisper, we need to remove any dependency on scripts being executed inline outside of Polymer. There's one place where this happens with setting a paper-dialog-scrollable element's parent dialog. This needs to happen only when the paper-dialog-scrollable is attached to the DOM after we parse out the response from a user get (when we are getting a listing of users to potentially add via checkboxes). To remove this script, I had to make a custom element that gets attached at the same time and fires its attached listener to actually set the parent dialog for the paper-dialog-scrollable. From there, I needed to add some CSS to make the dialog still display properly when rendered in this fashion.

The end result is a more secure CSP than allowing unsafe-inline and a cleaner overall setup for the scrollable dialog. Sorry for bundling this all together, but hopefully it makes sense.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/145)

<!-- Reviewable:end -->
