### PR TITLE
Make the invite code input readonly so it can be manually copied from when the copy button fails.

### DIFF
--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -70,7 +70,7 @@
           <p>{{resources.inviteCodeNeedServerText}}</p>
         </template>
         <template is="dom-if" if="[[inviteCodeJson.invite_code]]">
-          <paper-input disabled type="text" id="lastInviteCode" value="{{inviteCodeJson.invite_code}}"></paper-input>
+          <paper-input readonly type="text" id="lastInviteCode" value="{{inviteCodeJson.invite_code}}"></paper-input>
         </template>
       </div>
       <br>


### PR DESCRIPTION
So the last fix should have made the copy invite code button actually work, but from the Chromium bug and stackoverflow links below, this seems to be a support issue with OS X.

SO: http://stackoverflow.com/questions/36196248/execcommandcopy-fails-on-chrome-on-os-x
Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=552975

Thus, to mitigate the issue and make the invite code accessible to users on OS X in the meantime, I've made the input box itself readonly so the text can be manually copy and pasted. We can add support to notify users of this limitation at some later time if we like, but this seemed like a simple stopgap until then.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/146)

<!-- Reviewable:end -->
