### PR TITLE
Remove email from the key string as it's a security hole, and has no …

### DIFF
--- a/ufo/services/key_distributor.py
+++ b/ufo/services/key_distributor.py
@@ -34,8 +34,11 @@ class KeyDistributor(object):
       public_key = RSA.importKey(user.public_key)
       public_key_string = public_key.exportKey('OpenSSH')
 
+      # Do not include email at the end of the user_string as it's a security
+      # hole.  It's also just a comment without any specific use.
+      # If really necessary, encode special characters with something like json.
       user_string = (ssh_starting_portion + ' ' + public_key_string + ' ' +
-                     user.email + endline)
+                     endline)
       key_string += user_string
 
     return key_string

--- a/ufo/services/key_distributor_test.py
+++ b/ufo/services/key_distributor_test.py
@@ -27,7 +27,6 @@ class KeyDistributorTest(base_test.BaseTest):
     self.assertEquals(0, key_string.count('END PUBLIC KEY'))
 
     for fake_user in fake_users:
-      self.assertIn(fake_user.email, key_string)
       self.assertIn(
           RSA.importKey(fake_user.public_key).exportKey('OpenSSH'),
           key_string)


### PR DESCRIPTION
…specific use.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/153)

<!-- Reviewable:end -->
