### PR TITLE
Making OAuth Configuration Handle Required Attributes Properly

### DIFF
--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -68,20 +68,32 @@
          </p>
 
       <!-- TODO make this form be more useful -->
-      <form id="oauthConfigurationForm" method="post" action="{{resources.setup_url}}">
-        <paper-input label="Domain" name="domain" required on-keypress="submitIfEnter"></paper-input>
-        <paper-input label="OAuth Code" name="oauth_code" required on-keypress="submitIfEnter"></paper-input>
-        <template is="dom-if" if="{{!configuration.config.is_configured}}">
-          <paper-input label="{{resources.adminEmailLabel}}" name="admin_email"></paper-input>
-          <paper-input label="{{resources.adminPasswordlabel}}" name="admin_password" on-keypress="submitIfEnter"></paper-input>
-        </template>
-        <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
-        <div class="buttons">
-          <paper-button on-tap="submitOauth" class="form-submit-button anchor-button" type="submit">
-            <strong>{{resources.submitButtonText}}</strong>
-          </paper-button>
-        </div>
-      </form>
+      <template is="dom-if" if="{{configuration.config.is_configured}}">
+        <form id="oauthConfigurationForm" method="post" action="{{resources.setup_url}}">
+          <paper-input label="Domain" name="domain" required on-keypress="submitIfEnter"></paper-input>
+          <paper-input label="OAuth Code" name="oauth_code" required on-keypress="submitIfEnter"></paper-input>
+          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
+          <div class="buttons">
+            <paper-button on-tap="submitOauth" class="form-submit-button anchor-button" type="submit">
+              <strong>{{resources.submitButtonText}}</strong>
+            </paper-button>
+          </div>
+        </form>
+      </template>
+      <template is="dom-if" if="{{!configuration.config.is_configured}}">
+        <form id="oauthConfigurationForm" method="post" action="{{resources.setup_url}}">
+          <paper-input label="Domain" name="domain" on-keypress="submitIfEnter"></paper-input>
+          <paper-input label="OAuth Code" name="oauth_code" on-keypress="submitIfEnter"></paper-input>
+          <paper-input label="{{resources.adminEmailLabel}}" required name="admin_email"></paper-input>
+          <paper-input label="{{resources.adminPasswordlabel}}" required name="admin_password" on-keypress="submitIfEnter"></paper-input>
+          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
+          <div class="buttons">
+            <paper-button on-tap="submitOauth" class="form-submit-button anchor-button" type="submit">
+              <strong>{{resources.submitButtonText}}</strong>
+            </paper-button>
+          </div>
+        </form>
+      </template>
   </template>
 
   <script>
@@ -104,7 +116,20 @@
         return config.domain && config.credentials;
       },
       submitOauth: function(e, detail) {
-        this.$.oauthConfigurationForm.submit();
+        var form = this.querySelector('#oauthConfigurationForm');
+        var inputs = form.querySelectorAll('paper-input');
+        var shouldSubmit = true;
+        var i = 0;
+        for (; i < inputs.length; i++) {
+          // Separating this out so that all inputs are checked in case more
+          // than one is invalid. Otherwise, after one is invalid, no more will
+          // be checked or show invalid regardless of state.
+          isValid = inputs[i].validate();
+          shouldSubmit = shouldSubmit && isValid;
+        }
+        if (shouldSubmit) {
+          form.submit();
+        }
       },
       submitIfEnter: function(e) {
         if (e.keyCode === 13) {

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 {% block title %}Setup{% endblock %}
 {% block body %}
+  <paper-display-template resources="{{oauth_resources}}" id="oauthDisplayTemplate">
+    <header-container resources="{{oauth_resources}}">
+      <oauth-configuration resources="{{oauth_resources}}" configuration="{{oauth_configuration_resources}}">
+      </oauth-configuration>
+    </header-container>
+  </paper-display-template>
+
   <paper-display-template resources="{{user_resources}}" id="userDisplayTemplate">
     <left-icon-container resources="{{user_resources}}">
       <user-add-tabs resources="{{user_resources}}">
@@ -13,13 +20,6 @@
       <server-add-form resources="{{proxy_server_resources}}">
       </server-add-form>
     </left-icon-container>
-  </paper-display-template>
-
-  <paper-display-template resources="{{oauth_resources}}" id="oauthDisplayTemplate">
-    <header-container resources="{{oauth_resources}}">
-      <oauth-configuration resources="{{oauth_resources}}" configuration="{{oauth_configuration_resources}}">
-      </oauth-configuration>
-    </header-container>
   </paper-display-template>
 
   <paper-display-template resources="{{policy_resources}}" id="chromePolicyDisplayTemplate">


### PR DESCRIPTION
The domain and oauth code should only be required after initial setup (since those would be the only things you could change after initial setup). On initial setup, only an admin email and password is require, which disappears afterwards.

Also, moving the oauth/admin configuration up to the top of the setup page since it should happen before adding users/servers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/156)

<!-- Reviewable:end -->
