### PR TITLE
Updating public_key Field to host_public_key Since the Backend Expects host_public_key Now

### DIFF
--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -82,7 +82,7 @@
                        disabled
                        label="{{resources.hostPublicKeyLabel}}"
                        type="text"
-                       name="public_key"
+                       name="host_public_key"
                        required
                        pattern="{{resources.regexes.publicKeyPattern}}"
                        error-message="{{resources.regexes.publicKeyError}}"


### PR DESCRIPTION
We just missed this when we changed it before, and it came up when I ran functional tests earlier. Easy fix once I figured out what was wrong.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/167)

<!-- Reviewable:end -->
