### PR TITLE
nginx Configuration for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: gunicorn ufo:app --log-file=-
+web: bin/start-nginx gunicorn -c gunicorn.conf ufo:app --log-file=-
 worker: python worker.py
 clock: python clock.py

--- a/README.md
+++ b/README.md
@@ -340,6 +340,12 @@ To view the logs of an instance:
   * [More details here](https://www.digitalocean.com/community/tutorials/initial-server-setup-with-ubuntu-14-04) especially if you want to setup other non-root user.
 1. Save the corresponding private key to the management server for this proxy server.
 
+### Securing the Server with TLS
+
+When deployed on Heroku, the Management Server utilizes an [nginx buildpack](https://github.com/uProxy/nginx-buildpack) with [our own configuration](https://github.com/uProxy/nginx-buildpack/blob/master/config/nginx.conf.erb#L43) to provide a secure layer for HTTPS/HTTP + TLS. We redirect all traffic to the HTTPS version via a 301 Moved Permanently redirect and also provide the [HTTP Strict Transport Security (HSTS)](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) header to prevent clients that have visited via HTTPS to get downgraded to HTTP without the browser recognizing the potential attack. This is automatically configured out of the box during deployment and works by using Heroku’s SSL cert. When using a custom domain name, an SSL cert for that domain must be provided, but from our perspective it will function identically.
+
+Outside of Heroku however, the nginx setup is entirely avoided since we do not anticipate users to deploy with gunicorn or a Procfile (as required by Heroku). We encourage anyone running the management server off of Heroku to use a similar system to nginx to provide their own HTTPS/HTTP + TLS security where available.
+
 ## Troubleshooting
 
 ### SQLAlchemy Unable to Open Database/app.instance_path Not Pointing to App Directory

--- a/app.json
+++ b/app.json
@@ -25,6 +25,9 @@
     },
     {
       "url": "https://github.com/heroku/heroku-buildpack-python"
+    },
+    {
+      "url": "https://github.com/uProxy/nginx-buildpack"
     }
   ]
 }

--- a/gunicorn.conf
+++ b/gunicorn.conf
@@ -1,0 +1,7 @@
+# gunicorn.conf
+def when_ready(server):
+    # touch app-initialized when ready
+    open('/tmp/app-initialized', 'w').close()
+
+bind = 'unix:///tmp/nginx.socket'
+workers = 4


### PR DESCRIPTION
This adds nginx configuration during deployment on Heroku. The readme was updated specifying how this works, but basically it only gets triggered by the deployment steps on Heroku (via the Procfile and gunicorn) which means that standalone instances of the management server off of Heroku won't be impacted. I've added the 301 redirect to the HTTPS version and the HSTS header that will inform browsers if a client who has visited HTTPS gets downgraded back to HTTP somehow (man in the middle attack for instance). I forked the public nginx buildpack into uProxy so we can control exactly what goes into it and gated access similarly to this repo. You can view that repo here: https://github.com/uProxy/nginx-buildpack

This was tested on the nightly branch to ensure it works as intended on Heroku.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/175)

<!-- Reviewable:end -->
