### PR TITLE
Move Resource Dictionaries into One Large Shared Dictionary

### DIFF
--- a/ufo/services/resource_provider.py
+++ b/ufo/services/resource_provider.py
@@ -7,8 +7,23 @@ import ufo
 from ufo.services import regex
 
 
-def _get_resource_dictionary():
+def _get_resources():
   """Get the resources for all UI components including messages for i18n.
+
+    This dictionary of resources is returned as one giant blob for the time
+    being to simplify passing all these parameters to the UI. These could be
+    separated, but the messages for i18n are easier to edit and pickup in a
+    build process as a single file. Those messages will be extracted in the
+    future. The plan for these resources is to limit them to one object on the
+    UI rather than passing them around by utilizing Polymer behaviors
+    https://www.polymer-project.org/1.0/docs/devguide/behaviors . Overall,
+    whether this is one dictionary or multiple, they are set within the session
+    regardless of whether they are used, so they all get loaded during a
+    request, though perhaps not parsed out on the client side.
+
+    TODO(eholder): Refactor the UI to utilize Polymer behaviors to parse this
+    rather than passing it around between components.
+    TODO(eholder): Pull text messages and labels out of this for i18n.
 
     Returns:
       A dict of the resources for UI components.
@@ -238,8 +253,7 @@ def set_jinja_globals():
                       'Current jinja globals: %s' %
                       ufo.app.jinja_env.globals.keys())
 
-  ufo.app.jinja_env.globals['resource_dictionary'] = json.dumps(
-      _get_resource_dictionary())
+  ufo.app.jinja_env.globals['resources'] = json.dumps(_get_resources())
 
   # The resource keys should be present if set.
   ufo.app.logger.info('Finished setting resources into jinja globals.\n'

--- a/ufo/services/resource_provider.py
+++ b/ufo/services/resource_provider.py
@@ -7,11 +7,11 @@ import ufo
 from ufo.services import regex
 
 
-def _get_landing_resources():
-  """Get the resources for the general landing component.
+def _get_resource_dictionary():
+  """Get the resources for all UI components including messages for i18n.
 
     Returns:
-      A dict of the resources for the general landing component.
+      A dict of the resources for UI components.
   """
   return {
     'searchPageUrl': flask.url_for('search_page'),
@@ -47,34 +47,12 @@ def _get_landing_resources():
     'removeAdminSubmitText': 'Remove Admin',
     'errorTitleText': 'Something is Not Right',
     'closeText': 'Close',
-    'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.XSSI_PREFIX,
-  }
-
-def _get_login_resources():
-  """Get the resources for the login component.
-
-    Returns:
-      A dict of the resources for the login component.
-  """
-  return {
     'loginTitleText': 'Please Log In',
     'loginUrl': flask.url_for('login'),
     'emailLabel': 'Email',
     'passwordLabel': 'Password',
     'loginText': 'Login',
-    'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.XSSI_PREFIX,
     'recaptchaKey': ufo.app.config['RECAPTCHA_SITE_KEY'],
-  }
-
-def _get_oauth_resources():
-  """Get the resources for the oauth component.
-
-    Returns:
-      A dict of the resources for the oauth component.
-  """
-  return {
     'setup_url': flask.url_for('setup'),
     'oauthTitleText': 'Oauth Configuration',
     'welcomeText': ('Hey there! Welcome to the uProxy for Organizations '
@@ -104,19 +82,7 @@ def _get_oauth_resources():
     'connectYourDomainButtonText': 'Connect to Your Domain',
     'pasteTheCodeText': ('Once you finish authorizing access, please paste '
         'the code you receive in the box below.'),
-    'adminEmailLabel': 'Admin Email',
-    'adminPasswordlabel': 'Admin Password',
     'submitButtonText': 'Submit',
-    'jsonPrefix': ufo.XSSI_PREFIX,
-  }
-
-def _get_policy_resources():
-  """Get the resources for the chrome policy component.
-
-    Returns:
-      A dict of the resources for the chrome policy component.
-  """
-  return {
     'download_chrome_policy': flask.url_for('download_chrome_policy'),
     'policy_filename': 'chrome_policy.json',
     'chromePolicyTitleText': 'Chrome Policy',
@@ -141,17 +107,6 @@ def _get_policy_resources():
         'file you just downloaded. You may have to click override to edit '
         'Force Installation or Configure\'s values. Finally, click Save.'),
     'downloadText': 'Download',
-    'jsonPrefix': ufo.XSSI_PREFIX,
-  }
-
-
-def _get_proxy_server_resources():
-  """Get the resources for the proxy server component.
-
-    Returns:
-      A dict of the resources for the proxy server component.
-  """
-  return {
     'proxyServerAddUrl': flask.url_for('proxyserver_add'),
     'proxyServerAddIconUrl': flask.url_for('static',
                                            filename='img/add-servers.svg'),
@@ -162,7 +117,6 @@ def _get_proxy_server_resources():
     'proxyServerListUrl': flask.url_for('proxyserver_list'),
     'listLimit': 10,
     'proxyServerDetailsExpandText': 'Expand Server',
-    'closeText': 'Close',
     'proxyServerDetailsButtonId': 'serverDetailsButton',
     'editButtonId': 'serverEditButton',
     'proxyServerDetailsOverlayId': 'serverDetailsOverlay',
@@ -181,8 +135,6 @@ def _get_proxy_server_resources():
     'proxyServerModalId': 'serverModal',
     'dismissText': 'Cancel',
     'confirmText': 'Add Server',
-    'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.XSSI_PREFIX,
     'textAreaMaxRows': 10,
     'ipLabel': 'IP Address',
     'nameLabel': 'Server Name',
@@ -208,46 +160,23 @@ def _get_proxy_server_resources():
         'This public key is used to authenticate the proxy server.'),
     'rsaText': ('For now, please be sure to use an RSA key (the text should '
                 'begin with ssh-rsa)'),
-  }
-
-def _get_settings_resources():
-  """Get the resources for the settings configuration component.
-
-    Returns:
-      A dict of the resources for the settings configuration component.
-  """
-  return {
     'settingsTitleText': 'Management Server Settings',
     'getSettingsUrl': flask.url_for('get_settings'),
     'settingsEditUrl': flask.url_for('edit_settings'),
     'proxyValidityText': 'Enforce Proxy Server Check from Invitation Link',
     'networkJailText': 'Enforce Network Jail Before Google Login',
-    'saveText': 'Save',
-    'jsonPrefix': ufo.XSSI_PREFIX,
-  }
-
-def _get_user_resources():
-  """Get the resources for the user component(s).
-
-    Returns:
-      A dict of the resources for the user component(s).
-  """
-  return {
     'userAddUrl': flask.url_for('add_user'),
-    'userAddIconUrl': flask.url_for('static', filename='img/add-users.svg'),
     'userInverseAddIconUrl': flask.url_for(
         'static', filename='img/add-users-inverse.svg'),
     'userAddText': 'Add Users',
     'lookAgainText': 'Search Again',
     'userListId': 'userList',
     'userListUrl': flask.url_for('user_list'),
-    'listLimit': 10,
     'revokeToggleUrl': flask.url_for('user_toggle_revoked'),
     'rotateKeysUrl': flask.url_for('user_get_new_key_pair'),
     'inviteCodeUrl': flask.url_for('user_get_invite_code'),
     'userDeleteUrl': flask.url_for('delete_user'),
     'userDetailsExpandText': 'Expand User',
-    'closeText': 'Close',
     'userDetailsButtonId': 'userDetailsButton',
     'userDetailsOverlayId': 'userDetailsOverlay',
     'inviteCodeNeedServerText': ('Invite codes aren\'t available without any '
@@ -262,15 +191,11 @@ def _get_user_resources():
     'userDeleteLabel': 'Delete User',
     'userSeeAllText': 'See All Users',
     'userTitleText': 'Users',
-    'nameColumnHeader': 'Name',
     'emailColumnHeader': 'Email',
     'accessColumnHeader': 'Access',
     'userIconUrl': flask.url_for('static', filename='img/user.svg'),
     'userAddButtonId': 'addUserButton',
     'userModalId': 'userModal',
-    'dismissText': 'Cancel',
-    'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
-    'jsonPrefix': ufo.XSSI_PREFIX,
     'addFlowNoResults': 'No results found.',
     'groupAddTabId': 'groupAddTab',
     'groupAddTab': 'Search for Users in Group',
@@ -301,6 +226,8 @@ def _get_user_resources():
     'manualEmailAddressLabel': 'Email Address',
     'saveMultipleUsersButton': 'Add Users',
     'saveIndividualUserButton': 'Add User',
+    'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
+    'jsonPrefix': ufo.XSSI_PREFIX,
   }
 
 def set_jinja_globals():
@@ -311,20 +238,8 @@ def set_jinja_globals():
                       'Current jinja globals: %s' %
                       ufo.app.jinja_env.globals.keys())
 
-  ufo.app.jinja_env.globals['landing_resources'] = json.dumps(
-      _get_landing_resources())
-  ufo.app.jinja_env.globals['login_resources'] = json.dumps(
-      _get_login_resources())
-  ufo.app.jinja_env.globals['oauth_resources'] = json.dumps(
-      _get_oauth_resources())
-  ufo.app.jinja_env.globals['policy_resources'] = json.dumps(
-      _get_policy_resources())
-  ufo.app.jinja_env.globals['proxy_server_resources'] = (
-      json.dumps(_get_proxy_server_resources()))
-  ufo.app.jinja_env.globals['settings_resources'] = json.dumps(
-      _get_settings_resources())
-  ufo.app.jinja_env.globals['user_resources'] = json.dumps(
-      _get_user_resources())
+  ufo.app.jinja_env.globals['resource_dictionary'] = json.dumps(
+      _get_resource_dictionary())
 
   # The resource keys should be present if set.
   ufo.app.logger.info('Finished setting resources into jinja globals.\n'

--- a/ufo/static/paperDisplayTemplate.html
+++ b/ufo/static/paperDisplayTemplate.html
@@ -15,11 +15,6 @@
   <script>
     Polymer({
       is: 'paper-display-template',
-      properties: {
-        resources: {
-          type: Object,
-        },
-      },
     });
   </script>
 </dom-module>

--- a/ufo/static/ufoSearchBar.html
+++ b/ufo/static/ufoSearchBar.html
@@ -23,7 +23,7 @@
   </style>
   <template>
     <div class="middle horizontal layout center flex">
-      <form is="iron-form" method="GET" action="{{searchResources.searchJsonUrl}}" on-iron-form-presubmit="presubmit" on-iron-form-response="parseSearchResponse" id="searchForm" content-type="application/json" class="flex">
+      <form is="iron-form" method="GET" action="{{resources.searchJsonUrl}}" on-iron-form-presubmit="presubmit" on-iron-form-response="parseSearchResponse" id="searchForm" content-type="application/json" class="flex">
         <paper-input id="searchBar" no-label-float name="search_input" value="{{searchText}}">
           <paper-icon-button id="searchButton" icon="search" prefix on-tap="submitForm"></paper-icon-button>
           <paper-icon-button icon="arrow-back" suffix id="suffix" class="hideSuffix" on-tap="resetLists"></paper-icon-button>
@@ -40,13 +40,7 @@
     Polymer({
       is: 'ufo-search-bar',
       properties: {
-        userResources: {
-          type: Object,
-        },
-        proxyServerResources: {
-          type: Object,
-        },
-        searchResources: {
+        resources: {
           type: Object,
         },
         loading: {
@@ -65,15 +59,15 @@
       },
       ready: function() {
         this.$.searchForm.request.handleAs = "json";
-        this.$.searchForm.request.jsonPrefix = this.searchResources.jsonPrefix;
+        this.$.searchForm.request.jsonPrefix = this.resources.jsonPrefix;
       },
       presubmit: function() {
-        var userList = document.getElementById(this.userResources.userListId);
+        var userList = document.getElementById(this.resources.userListId);
         var serverList = document.getElementById(
-          this.proxyServerResources.proxyServerListId);
+          this.resources.proxyServerListId);
         if (!userList && !serverList) {
           var queryString = "?search_text=" + this.$.hiddenSearch.value;
-          var locationString = this.searchResources.searchPageUrl + queryString;
+          var locationString = this.resources.searchPageUrl + queryString;
           window.location.href = locationString;
         }
         this.set('loading', true);
@@ -96,11 +90,11 @@
       parseSearchResponse: function(e, details) {
         var searchJson = this.$.searchForm.request.lastResponse;
         if (searchJson.users) {
-          this.sendJsonToList(searchJson.users, this.userResources.userListId);
+          this.sendJsonToList(searchJson.users, this.resources.userListId);
         }
         if (searchJson.servers) {
           this.sendJsonToList(searchJson.servers,
-            this.proxyServerResources.proxyServerListId);
+            this.resources.proxyServerListId);
         }
         this.set('loading', false);
       },
@@ -111,12 +105,12 @@
         }
       },
       resetLists: function(e, details) {
-        var userList = document.getElementById(this.userResources.userListId);
+        var userList = document.getElementById(this.resources.userListId);
         if (userList) {
           userList.resendRequest();
         }
         var serverList = document.getElementById(
-          this.proxyServerResources.proxyServerListId);
+          this.resources.proxyServerListId);
         if (serverList) {
           serverList.resendRequest();
         }

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -47,7 +47,7 @@
           <div class="flex"></div>
           <div class="vertical layout flex-4">
             <div class="verticalSpacer"><p></div>
-            <ufo-search-bar class="flex toHideOnLoginPage" user-resources="{{user_resources}}" proxy-server-resources="{{proxy_server_resources}}" search-resources="{{landing_resources}}">
+            <ufo-search-bar class="flex toHideOnLoginPage" resources="{{resource_dictionary}}">
             </ufo-search-bar>
             <div class="verticalSpacer"></div>
           </div>
@@ -60,7 +60,7 @@
   </div>
   <div class="layout vertical">
     <div class="horizontal center-justified layout" id="dialogMenuHolder">
-      <ufo-dropdown-menu resources="{{landing_resources}}">
+      <ufo-dropdown-menu resources="{{resource_dictionary}}">
       </ufo-dropdown-menu>
     </div>
   </div>
@@ -69,7 +69,7 @@
     <br>
     <p></p>
   </div>
-  <error-notification resources="{{landing_resources}}" id='error-notification'></error-notification>
+  <error-notification resources="{{resource_dictionary}}" id='error-notification'></error-notification>
 
   <script src="{{ url_for('static', filename='globalHelperFunctions.js') }}"></script>
   <input id="hiddenCopyInput" type="hidden" value=""/>

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -47,7 +47,7 @@
           <div class="flex"></div>
           <div class="vertical layout flex-4">
             <div class="verticalSpacer"><p></div>
-            <ufo-search-bar class="flex toHideOnLoginPage" resources="{{resource_dictionary}}">
+            <ufo-search-bar class="flex toHideOnLoginPage" resources="{{resources}}">
             </ufo-search-bar>
             <div class="verticalSpacer"></div>
           </div>
@@ -60,7 +60,7 @@
   </div>
   <div class="layout vertical">
     <div class="horizontal center-justified layout" id="dialogMenuHolder">
-      <ufo-dropdown-menu resources="{{resource_dictionary}}">
+      <ufo-dropdown-menu resources="{{resources}}">
       </ufo-dropdown-menu>
     </div>
   </div>
@@ -69,7 +69,7 @@
     <br>
     <p></p>
   </div>
-  <error-notification resources="{{resource_dictionary}}" id='error-notification'></error-notification>
+  <error-notification resources="{{resources}}" id='error-notification'></error-notification>
 
   <script src="{{ url_for('static', filename='globalHelperFunctions.js') }}"></script>
   <input id="hiddenCopyInput" type="hidden" value=""/>

--- a/ufo/templates/landing.html
+++ b/ufo/templates/landing.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
 {% block title %}Landing{% endblock %}
 {% block body %}
-  <paper-display-template resources="{{user_resources}}" id="userDisplayTemplate">
-    <header-container resources="{{user_resources}}" has-add-flow="true" header-type="user">
-      <user-list resources="{{user_resources}}" id="userList" auto-get=true>
+  <paper-display-template id="userDisplayTemplate">
+    <header-container resources="{{resource_dictionary}}" has-add-flow="true" header-type="user">
+      <user-list resources="{{resource_dictionary}}" id="userList" auto-get=true>
       </user-list>
     </header-container>
   </paper-display-template>
-  <paper-display-template resources="{{proxy_server_resources}}" id="proxyServerDisplayTemplate">
-    <header-container resources="{{proxy_server_resources}}" has-add-flow="true" header-type="proxyServer">
-      <server-list resources="{{proxy_server_resources}}" id="proxyList" auto-get=true>
+  <paper-display-template id="proxyServerDisplayTemplate">
+    <header-container resources="{{resource_dictionary}}" has-add-flow="true" header-type="proxyServer">
+      <server-list resources="{{resource_dictionary}}" id="proxyList" auto-get=true>
       </server-list>
     </header-container>
   </paper-display-template>
   {% if session['domain'] %}
-    <paper-display-template resources="{{policy_resources}}" id="chromePolicyDisplayTemplate">
-      <header-container resources="{{policy_resources}}" header-type="chromePolicy">
-        <chrome-policy resources="{{policy_resources}}">
+    <paper-display-template id="chromePolicyDisplayTemplate">
+      <header-container resources="{{resource_dictionary}}" header-type="chromePolicy">
+        <chrome-policy resources="{{resource_dictionary}}">
         </chrome-policy>
       </header-container>
     </paper-display-template>

--- a/ufo/templates/landing.html
+++ b/ufo/templates/landing.html
@@ -2,21 +2,21 @@
 {% block title %}Landing{% endblock %}
 {% block body %}
   <paper-display-template id="userDisplayTemplate">
-    <header-container resources="{{resource_dictionary}}" has-add-flow="true" header-type="user">
-      <user-list resources="{{resource_dictionary}}" id="userList" auto-get=true>
+    <header-container resources="{{resources}}" has-add-flow="true" header-type="user">
+      <user-list resources="{{resources}}" id="userList" auto-get=true>
       </user-list>
     </header-container>
   </paper-display-template>
   <paper-display-template id="proxyServerDisplayTemplate">
-    <header-container resources="{{resource_dictionary}}" has-add-flow="true" header-type="proxyServer">
-      <server-list resources="{{resource_dictionary}}" id="proxyList" auto-get=true>
+    <header-container resources="{{resources}}" has-add-flow="true" header-type="proxyServer">
+      <server-list resources="{{resources}}" id="proxyList" auto-get=true>
       </server-list>
     </header-container>
   </paper-display-template>
   {% if session['domain'] %}
     <paper-display-template id="chromePolicyDisplayTemplate">
-      <header-container resources="{{resource_dictionary}}" header-type="chromePolicy">
-        <chrome-policy resources="{{resource_dictionary}}">
+      <header-container resources="{{resources}}" header-type="chromePolicy">
+        <chrome-policy resources="{{resources}}">
         </chrome-policy>
       </header-container>
     </paper-display-template>

--- a/ufo/templates/login.html
+++ b/ufo/templates/login.html
@@ -7,11 +7,11 @@
   }
   </style>
   <paper-display-template>
-    <header-container resources="{{resource_dictionary}}" header-type="login">
+    <header-container resources="{{resources}}" header-type="login">
       {% if session['should_show_recaptcha'] %}
-        <login-form resources="{{resource_dictionary}}" failures="{{session['failures'] or 0}}" should-show-recaptcha></login-form>
+        <login-form resources="{{resources}}" failures="{{session['failures'] or 0}}" should-show-recaptcha></login-form>
       {% else %}
-        <login-form resources="{{resource_dictionary}}" failures="{{session['failures'] or 0}}"></login-form>
+        <login-form resources="{{resources}}" failures="{{session['failures'] or 0}}"></login-form>
       {% endif %}
     </header-container>
   </paper-display-template>

--- a/ufo/templates/login.html
+++ b/ufo/templates/login.html
@@ -6,12 +6,12 @@
     display: none;
   }
   </style>
-  <paper-display-template resources="{{login_resources}}">
-    <header-container resources="{{login_resources}}" header-type="login">
+  <paper-display-template>
+    <header-container resources="{{resource_dictionary}}" header-type="login">
       {% if session['should_show_recaptcha'] %}
-        <login-form resources="{{login_resources}}" failures="{{session['failures'] or 0}}" should-show-recaptcha></login-form>
+        <login-form resources="{{resource_dictionary}}" failures="{{session['failures'] or 0}}" should-show-recaptcha></login-form>
       {% else %}
-        <login-form resources="{{login_resources}}" failures="{{session['failures'] or 0}}"></login-form>
+        <login-form resources="{{resource_dictionary}}" failures="{{session['failures'] or 0}}"></login-form>
       {% endif %}
     </header-container>
   </paper-display-template>

--- a/ufo/templates/search.html
+++ b/ufo/templates/search.html
@@ -3,15 +3,15 @@
 {% block body %}
 <!-- TODO(eholder): Verify this page will/will not be needed according
                     to John Cassidy and remove or keep as appropriate. -->
-  <paper-display-template resources="{{user_resources}}" id="userDisplayTemplate">
-    <header-container resources="{{user_resources}}" header-type="user">
-      <user-list resources="{{user_resources}}" id="userList" ajax-response="{{user_items}}">
+  <paper-display-template id="userDisplayTemplate">
+    <header-container resources="{{resource_dictionary}}" header-type="user">
+      <user-list resources="{{resource_dictionary}}" id="userList" ajax-response="{{user_items}}">
       </user-list>
     </header-container>
   </paper-display-template>
-  <paper-display-template resources="{{proxy_server_resources}}" id="proxyServerDisplayTemplate">
-    <header-container resources="{{proxy_server_resources}}" header-type="proxyServer">
-      <server-list resources="{{proxy_server_resources}}" id="proxyList" ajax-response="{{proxy_server_items}}">
+  <paper-display-template id="proxyServerDisplayTemplate">
+    <header-container resources="{{resource_dictionary}}" header-type="proxyServer">
+      <server-list resources="{{resource_dictionary}}" id="proxyList" ajax-response="{{proxy_server_items}}">
       </server-list>
     </header-container>
   </paper-display-template>

--- a/ufo/templates/search.html
+++ b/ufo/templates/search.html
@@ -4,14 +4,14 @@
 <!-- TODO(eholder): Verify this page will/will not be needed according
                     to John Cassidy and remove or keep as appropriate. -->
   <paper-display-template id="userDisplayTemplate">
-    <header-container resources="{{resource_dictionary}}" header-type="user">
-      <user-list resources="{{resource_dictionary}}" id="userList" ajax-response="{{user_items}}">
+    <header-container resources="{{resources}}" header-type="user">
+      <user-list resources="{{resources}}" id="userList" ajax-response="{{user_items}}">
       </user-list>
     </header-container>
   </paper-display-template>
   <paper-display-template id="proxyServerDisplayTemplate">
-    <header-container resources="{{resource_dictionary}}" header-type="proxyServer">
-      <server-list resources="{{resource_dictionary}}" id="proxyList" ajax-response="{{proxy_server_items}}">
+    <header-container resources="{{resources}}" header-type="proxyServer">
+      <server-list resources="{{resources}}" id="proxyList" ajax-response="{{proxy_server_items}}">
       </server-list>
     </header-container>
   </paper-display-template>

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -2,38 +2,38 @@
 {% block title %}Setup{% endblock %}
 {% block body %}
   <paper-display-template id="oauthDisplayTemplate">
-    <header-container resources="{{resource_dictionary}}" header-type="oauth">
-      <oauth-configuration resources="{{resource_dictionary}}" configuration="{{oauth_configuration_resources}}">
+    <header-container resources="{{resources}}" header-type="oauth">
+      <oauth-configuration resources="{{resources}}" configuration="{{oauth_configuration_resources}}">
       </oauth-configuration>
     </header-container>
   </paper-display-template>
 
   <paper-display-template id="userDisplayTemplate">
-    <left-icon-container resources="{{resource_dictionary}}" add-type="user">
-      <user-add-tabs resources="{{resource_dictionary}}">
+    <left-icon-container resources="{{resources}}" add-type="user">
+      <user-add-tabs resources="{{resources}}">
       </user-add-tabs>
     </left-icon-container>
   </paper-display-template>
 
   <paper-display-template id="proxyServerDisplayTemplate">
-    <left-icon-container resources="{{resource_dictionary}}" add-type="proxyServer">
-      <server-add-form resources="{{resource_dictionary}}">
+    <left-icon-container resources="{{resources}}" add-type="proxyServer">
+      <server-add-form resources="{{resources}}">
       </server-add-form>
     </left-icon-container>
   </paper-display-template>
 
   {% if session['domain'] %}
     <paper-display-template id="chromePolicyDisplayTemplate">
-      <header-container resources="{{resource_dictionary}}" header-type="chromePolicy">
-        <chrome-policy resources="{{resource_dictionary}}">
+      <header-container resources="{{resources}}" header-type="chromePolicy">
+        <chrome-policy resources="{{resources}}">
         </chrome-policy>
       </header-container>
     </paper-display-template>
   {% endif %}
 
   <paper-display-template id="settingsDisplayTemplate">
-    <header-container resources="{{resource_dictionary}}" header-type="settings">
-      <settings-configuration resources="{{resource_dictionary}}">
+    <header-container resources="{{resources}}" header-type="settings">
+      <settings-configuration resources="{{resources}}">
       </settings-configuration>
     </header-container>
   </paper-display-template>

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -1,39 +1,39 @@
 {% extends "base.html" %}
 {% block title %}Setup{% endblock %}
 {% block body %}
-  <paper-display-template resources="{{oauth_resources}}" id="oauthDisplayTemplate">
-    <header-container resources="{{oauth_resources}}" header-type="oauth">
-      <oauth-configuration resources="{{oauth_resources}}" configuration="{{oauth_configuration_resources}}">
+  <paper-display-template id="oauthDisplayTemplate">
+    <header-container resources="{{resource_dictionary}}" header-type="oauth">
+      <oauth-configuration resources="{{resource_dictionary}}" configuration="{{oauth_configuration_resources}}">
       </oauth-configuration>
     </header-container>
   </paper-display-template>
 
-  <paper-display-template resources="{{user_resources}}" id="userDisplayTemplate">
-    <left-icon-container resources="{{user_resources}}" add-type="user">
-      <user-add-tabs resources="{{user_resources}}">
+  <paper-display-template id="userDisplayTemplate">
+    <left-icon-container resources="{{resource_dictionary}}" add-type="user">
+      <user-add-tabs resources="{{resource_dictionary}}">
       </user-add-tabs>
     </left-icon-container>
   </paper-display-template>
 
-  <paper-display-template resources="{{proxy_server_resources}}" id="proxyServerDisplayTemplate">
-    <left-icon-container resources="{{proxy_server_resources}}" add-type="proxyServer">
-      <server-add-form resources="{{proxy_server_resources}}">
+  <paper-display-template id="proxyServerDisplayTemplate">
+    <left-icon-container resources="{{resource_dictionary}}" add-type="proxyServer">
+      <server-add-form resources="{{resource_dictionary}}">
       </server-add-form>
     </left-icon-container>
   </paper-display-template>
 
   {% if session['domain'] %}
-    <paper-display-template resources="{{policy_resources}}" id="chromePolicyDisplayTemplate">
-      <header-container resources="{{policy_resources}}" header-type="chromePolicy">
-        <chrome-policy resources="{{policy_resources}}">
+    <paper-display-template id="chromePolicyDisplayTemplate">
+      <header-container resources="{{resource_dictionary}}" header-type="chromePolicy">
+        <chrome-policy resources="{{resource_dictionary}}">
         </chrome-policy>
       </header-container>
     </paper-display-template>
   {% endif %}
 
-  <paper-display-template resources="{{settings_resources}}" id="settingsDisplayTemplate">
-    <header-container resources="{{settings_resources}}" header-type="settings">
-      <settings-configuration resources="{{settings_resources}}">
+  <paper-display-template id="settingsDisplayTemplate">
+    <header-container resources="{{resource_dictionary}}" header-type="settings">
+      <settings-configuration resources="{{resource_dictionary}}">
       </settings-configuration>
     </header-container>
   </paper-display-template>


### PR DESCRIPTION
This removes any duplicate entries such as regexes, the JSON prefix, and a few labels (which were the same as per the last PR), and combines all resource dictionaries into one. I verified this works by running the web driver tests locally.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/185)

<!-- Reviewable:end -->
