### PR TITLE
Making Dialog Cancellations Reset Contained Forms

### DIFF
--- a/ufo/static/addModal.html
+++ b/ufo/static/addModal.html
@@ -38,7 +38,6 @@
         },
       },
       listeners: {
-        'iron-form-error': 'handleFormError',
         'iron-overlay-canceled': 'handleCancelled',
       },
       ready: function() {

--- a/ufo/static/addModal.html
+++ b/ufo/static/addModal.html
@@ -37,6 +37,10 @@
           value: '',
         },
       },
+      listeners: {
+        'iron-form-error': 'handleFormError',
+        'iron-overlay-canceled': 'handleCancelled',
+      },
       ready: function() {
         switch (this.addType) {
           case 'proxyServer':
@@ -49,6 +53,16 @@
             this.addText = this.resources.userAddText;
             this.isUser= true;
             break;
+        }
+      },
+      handleCancelled: function(event, detail) {
+        var serverAdd = this.querySelector('server-add-form');
+        var userAdd = this.querySelector('user-add-tabs');
+        if (this.isProxyServer && serverAdd) {
+          serverAdd.closeModal();
+        }
+        if (this.isUser && userAdd) {
+          userAdd.closeModal();
         }
       },
     });

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -140,6 +140,7 @@
       },
       listeners: {
         'iron-form-error': 'handleFormError',
+        'iron-overlay-canceled': 'closeDialog',
       },
       ready: function() {
         this.$.serverEditForm.request.handleAs = "json";

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -87,11 +87,10 @@
       },
       closeModal: function() {
         this.set('loading', false);
+        this.resetForm();
         serverModal = document.getElementById('serverModal');
         if (serverModal) {
           document.getElementById('serverModal').close();
-        } else {
-          this.resetForm();
         }
       },
       handleFormError: function(event, detail) {

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -188,6 +188,7 @@
         this.set('loading', false);
       },
       closeModal: function() {
+        this.set('loading', false);
         var userAddTabs = document.getElementsByTagName('user-add-tabs');
         if (userAddTabs && userAddTabs[0]) {
           userAddTabs[0].closeModal();

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -188,15 +188,13 @@
         this.set('loading', false);
       },
       closeModal: function() {
-        this.set('loading', false);
-        var userModal = document.getElementById('userModal');
-        if (userModal) {
-          userModal.close();
+        var userAddTabs = document.getElementsByTagName('user-add-tabs');
+        if (userAddTabs && userAddTabs[0]) {
+          userAddTabs[0].closeModal();
         }
       },
       parsePostResponse: function(e, detail) {
         this.sendUsersJsonToList(e.target.request.lastResponse);
-        this.resetForms();
         this.closeModal();
       },
       handleFormError: function(event, detail) {
@@ -211,7 +209,7 @@
         var errorDetail = {'detail': jsonObj};
         var errorEvent = new CustomEvent('ApplicationError', errorDetail);
         document.getElementById('error-notification').dispatchEvent(errorEvent);
-        this.closeModal();
+        this.set('loading', false);
       },
       resetForms: function(e, detail) {
         this.set('showInputFields', true);

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -138,6 +138,12 @@
         this.querySelector('#manualAdd').submit();
       },
       closeModal: function() {
+        this.resetForm();
+        var subForms = this.querySelectorAll('user-add-form');
+        var i;
+        for (i = 0; i < subForms.length; i++) {
+          subForms[i].resetForms();
+        }
         this.set('loading', false);
         var userModal = document.getElementById('userModal');
         if (userModal) {
@@ -146,7 +152,6 @@
       },
       parsePostResponse: function(e, detail) {
         this.sendUsersJsonToList(e.target.request.lastResponse);
-        this.resetForm();
         this.closeModal();
       },
       handleFormError: function(event, detail) {
@@ -161,7 +166,7 @@
         var errorDetail = {'detail': jsonObj};
         var errorEvent = new CustomEvent('ApplicationError', errorDetail);
         document.getElementById('error-notification').dispatchEvent(errorEvent);
-        this.closeModal();
+        this.set('loading', false);
       },
       resetForm: function() {
         var formElem = document.getElementById('manualAdd');


### PR DESCRIPTION
This makes the user and server add forms along with server edit not track state when exited. When these forms are modals, it is easy to force them to go through a single close dialog function where we can simply wipe the state. However, when allowing click outside to cancel or hitting the escape key to cancel, this fires a separate event. By setting a listener for that event and calling the appropriate close function, we achieve the same overall behavior.

I updated the close flow for the user add tabs and form elements to streamline this process. Now a close registered in any form (group add, individual add, or domain add) bubbles up to the tabs element which then resets each sub form and closes the modal. This is overall nicer than each form having a means of resetting each other form along with itself before closing.

Similarly in the add modal element, the listener for the cancel event gets delegated down to either the user add tabs to close (achieving the same flow as above) or the server add form to close.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/188)

<!-- Reviewable:end -->
