### PR TITLE
Adjust When XSRF Token is Looked Up for Rendering Improvement

### DIFF
--- a/ufo/static/chromePolicy.html
+++ b/ufo/static/chromePolicy.html
@@ -59,7 +59,10 @@
         },
       },
       ready: function() {
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/chromePolicy.html
+++ b/ufo/static/chromePolicy.html
@@ -28,7 +28,7 @@
       </p>
       <div class="buttons">
         <form is="iron-form" id="chromePolicyForm" method="post" action="{{resources.download_chrome_policy}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseChromePolicyResponse">
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+          <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           <template is="dom-if" if="{{loading}}">
             <paper-spinner id="chromePolicySpinner" active$={{loading}}></paper-spinner>
           </template>
@@ -58,11 +58,11 @@
           notify: true,
         },
       },
+      ready: function() {
+        this.xsrfToken = document.getElementById('globalXsrf').value;
+      },
       enableSpinner: function() {
         this.set('loading', true);
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       submitChromePolicy: function(e, detail) {
         this.$.chromePolicyForm.submit();

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -93,7 +93,7 @@
           <br>
           <p class="editElements hideElement">{{resources.hostPublicKeyText}}</p>
           <p class="editElements hideElement">{{resources.rsaText}}</p>
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+          <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           <input type="hidden" name="server_id" value="{{item.id}}">
         </form>
       </div>
@@ -107,7 +107,7 @@
         </paper-button>
         <form is="iron-form" id="serverDeleteForm" method="post" action="{{resources.proxyServerDeleteUrl}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
           <input type="hidden" name="server_id" value="{{item.id}}">
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+          <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           <paper-button on-tap="submitForm" class="delete-button" id="serverDeleteButton" type="submit">
             <iron-icon icon="delete"></iron-icon>
             <strong>{{resources.proxyServerDeleteLabel}}</strong>
@@ -147,12 +147,10 @@
         this.$.serverEditForm.request.jsonPrefix = this.resources.jsonPrefix;
         this.$.serverDeleteForm.request.handleAs = "json";
         this.$.serverDeleteForm.request.jsonPrefix = this.resources.jsonPrefix;
+        this.xsrfToken = document.getElementById('globalXsrf').value;
       },
       enableSpinner: function() {
         this.set('loading', true);
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       submitForm: function(e, detail) {
         var elem = e.target;

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -147,7 +147,10 @@
         this.$.serverEditForm.request.jsonPrefix = this.resources.jsonPrefix;
         this.$.serverDeleteForm.request.handleAs = "json";
         this.$.serverDeleteForm.request.jsonPrefix = this.resources.jsonPrefix;
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/loginForm.html
+++ b/ufo/static/loginForm.html
@@ -30,7 +30,7 @@
         </div>
       </template>
 
-      <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+      <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
     </form>
     <div class="buttons">
       <paper-button on-tap="submitLoginForm" class="anchor-button" type="submit" id="signIn">
@@ -54,14 +54,14 @@
           value: false,
         },
       },
+      ready: function() {
+        this.xsrfToken = document.getElementById('globalXsrf').value;
+      },
       attached: function() {
         if (this.shouldShowRecaptcha) {
           this.querySelector('#recaptchaDiv')
             .setAttribute('data-sitekey', this.resources.recaptchaKey);
         }
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       submitLoginForm: function() {
         this.querySelector('#loginForm').submit();

--- a/ufo/static/loginForm.html
+++ b/ufo/static/loginForm.html
@@ -55,7 +55,10 @@
         },
       },
       ready: function() {
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       attached: function() {
         if (this.shouldShowRecaptcha) {

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -110,7 +110,10 @@
         },
       },
       ready: function() {
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       isDomainConfigured: function(config) {
         return config.domain && config.credentials;

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -72,7 +72,7 @@
         <form id="oauthConfigurationForm" method="post" action="{{resources.setup_url}}">
           <paper-input label="Domain" name="domain" required on-keypress="submitIfEnter"></paper-input>
           <paper-input label="OAuth Code" name="oauth_code" required on-keypress="submitIfEnter"></paper-input>
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
+          <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
           <div class="buttons">
             <paper-button on-tap="submitOauth" class="form-submit-button anchor-button" type="submit">
               <strong>{{resources.submitButtonText}}</strong>
@@ -86,7 +86,7 @@
           <paper-input label="OAuth Code" name="oauth_code" on-keypress="submitIfEnter"></paper-input>
           <paper-input label="{{resources.adminEmailLabel}}" required name="admin_email"></paper-input>
           <paper-input label="{{resources.adminPasswordlabel}}" required name="admin_password" on-keypress="submitIfEnter"></paper-input>
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
+          <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
           <div class="buttons">
             <paper-button on-tap="submitOauth" class="form-submit-button anchor-button" type="submit">
               <strong>{{resources.submitButtonText}}</strong>
@@ -109,8 +109,8 @@
           notify: true,
         },
       },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
+      ready: function() {
+        this.xsrfToken = document.getElementById('globalXsrf').value;
       },
       isDomainConfigured: function(config) {
         return config.domain && config.credentials;

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -45,7 +45,7 @@
         <br>
         <p>{{resources.hostPublicKeyText}}</p>
         <p>{{resources.rsaText}}</p>
-        <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+        <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
       </form>
       <div class="buttons">
         <paper-button class="anchor-button" dialog-dismiss on-tap="resetForm">
@@ -78,6 +78,7 @@
       ready: function() {
         this.$.serverAddForm.request.handleAs = "json";
         this.$.serverAddForm.request.jsonPrefix = this.resources.jsonPrefix;
+        this.xsrfToken = document.getElementById('globalXsrf').value;
       },
       enableSpinner: function() {
         this.set('loading', true);
@@ -119,9 +120,6 @@
       },
       resetForm: function(e, details) {
         document.getElementById('serverAddForm').reset();
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       submitIfEnter: function(e) {
         if (e.keyCode === 13) {

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -78,7 +78,10 @@
       ready: function() {
         this.$.serverAddForm.request.handleAs = "json";
         this.$.serverAddForm.request.jsonPrefix = this.resources.jsonPrefix;
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/serverList.html
+++ b/ufo/static/serverList.html
@@ -143,9 +143,6 @@
       enableSpinner: function() {
         this.set('loading', true);
       },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
-      },
       _findAncestorMatchingTagnameFromTarget: function(target, tagName) {
         var elem = target;
         while (elem.tagName.toLowerCase() !== tagName) {

--- a/ufo/static/settingsConfiguration.html
+++ b/ufo/static/settingsConfiguration.html
@@ -26,7 +26,7 @@
       <br>
       <ufo-toggle-input input-name="enforce_network_jail" button-text="{{resources.networkJailText}}" checked$={{ajaxResponse.enforce_network_jail}}></ufo-toggle-input>
       <br>
-      <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+      <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
       <div class="buttons">
         <template is="dom-if" if="{{loading}}">
           <paper-spinner id="settingsSpinner" active$={{loading}}></paper-spinner>
@@ -57,12 +57,10 @@
       ready: function() {
         this.$.policyConfigForm.request.handleAs = "json";
         this.$.policyConfigForm.request.jsonPrefix = this.resources.jsonPrefix;
+        this.xsrfToken = document.getElementById('globalXsrf').value;
       },
       enableSpinner: function() {
         this.set('loading', true);
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       submitConfig: function(e, detail) {
         this.$.policyConfigForm.submit();

--- a/ufo/static/settingsConfiguration.html
+++ b/ufo/static/settingsConfiguration.html
@@ -57,7 +57,10 @@
       ready: function() {
         this.$.policyConfigForm.request.handleAs = "json";
         this.$.policyConfigForm.request.jsonPrefix = this.resources.jsonPrefix;
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -205,7 +205,10 @@
         this.$.changeAdminPasswordForm.request.jsonPrefix = this.resources.jsonPrefix;
         this.$.removeAdminForm.request.handleAs = "json";
         this.$.removeAdminForm.request.jsonPrefix = this.resources.jsonPrefix;
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       openMenu: function() {
         this.$.ufoDropdownMenu.open();

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -75,7 +75,7 @@
         <paper-icon-item class="dropdown-button">
           <iron-icon class="dropdown-icon" icon="subdirectory-arrow-right" item-icon></iron-icon>
           <form id="logoutForm" method="post" action="{{resources.logoutUrl}}">
-            <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
+            <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
             <paper-button type="submit" on-tap="submitLogoutForm" id="logoutButton">
               <strong>{{resources.logoutText}}</strong>
             </paper-button>
@@ -99,7 +99,7 @@
         <paper-input label="{{resources.adminPasswordlabel}}" id="paperAdminPassword" name="paperPassword" required on-keypress="submitIfEnter"></paper-input>
         <input type="hidden" name="admin_email" id="jsonEmail" value="" />
         <input type="hidden" name="admin_password" id="jsonPassword" value="" />
-        <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}" />
+        <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
         <paper-button on-tap="submitAddAdminForm" class="floatToTheRight anchor-button" id="adminFormSubmitButton" type="submit">
           <strong>{{resources.addAdminSubmitText}}</strong>
         </paper-button>
@@ -122,7 +122,7 @@
         <paper-input label="{{resources.changeAdminPasswordNewLabel}}" id="paperAdminNewPassword" name="paperAdminNewPassword" required on-keypress="submitIfEnter"></paper-input>
         <input type="hidden" name="old_password" id="jsonOldPassword" value="" />
         <input type="hidden" name="new_password" id="jsonNewPassword" value="" />
-        <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+        <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
       </form>
       <div class="buttons">
         <paper-button on-tap="submitChangeAdminPasswordForm" class="anchor-button" id="changeAdminPasswordSubmitButton" type="submit"><strong>{{resources.changeAdminPasswordSubmitText}}</strong></paper-button>
@@ -156,7 +156,7 @@
             </template>
           </paper-menu>
           <input type="hidden" id="hiddenAdminId" name="admin_id" value="">
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+          <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
         </form>
       </paper-dialog-scrollable>
       <div class="buttons">
@@ -205,9 +205,7 @@
         this.$.changeAdminPasswordForm.request.jsonPrefix = this.resources.jsonPrefix;
         this.$.removeAdminForm.request.handleAs = "json";
         this.$.removeAdminForm.request.jsonPrefix = this.resources.jsonPrefix;
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
+        this.xsrfToken = document.getElementById('globalXsrf').value;
       },
       openMenu: function() {
         this.$.ufoDropdownMenu.open();

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -162,7 +162,10 @@
         'iron-form-error': 'handleFormError',
       },
       ready: function() {
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.formId);

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -53,7 +53,7 @@
                 </template>
               </paper-listbox>
               <input type="hidden" id="hiddenUsers" name="users" value="{{usersJson}}">
-              <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+              <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
             </form>
           </paper-dialog-scrollable>
           <set-scrollable-dialog-to-modal></set-scrollable-dialog-to-modal>
@@ -76,7 +76,7 @@
             </paper-listbox>
             <br>
             <input type="hidden" id="hiddenUsers" name="users" value="{{usersJson}}">
-            <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+            <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           </form>
         </template>
         <paper-button on-tap="resetForms" class="anchor-button addTopMargin"><strong>{{resources.lookAgainText}}</strong></paper-button>
@@ -161,6 +161,9 @@
       listeners: {
         'iron-form-error': 'handleFormError',
       },
+      ready: function() {
+        this.xsrfToken = document.getElementById('globalXsrf').value;
+      },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.formId);
         addForm.request.handleAs = "json";
@@ -230,9 +233,6 @@
       },
       idMatches: function(id, string1) {
         return id === string1;
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       updateCheckedUsers: function(e) {
         var checkboxElem = event.path[0];

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -74,7 +74,7 @@
             </paper-input>
             <input type="hidden" name="users" id="manualUserInput" value="">
             <input type="hidden" name="manual" value="true">
-            <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+            <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
             <br>
           </form>
           <div class="buttons">
@@ -114,6 +114,9 @@
       },
       listeners: {
         'iron-form-error': 'handleFormError',
+      },
+      ready: function() {
+        this.xsrfToken = document.getElementById('globalXsrf').value;
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.resources.manualAddFormId);
@@ -179,9 +182,6 @@
         if (listElem) {
           listElem.setAjaxResponse(updatedUsersJson);
         }
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       submitIfEnter: function(e) {
         if (e.keyCode === 13) {

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -116,7 +116,10 @@
         'iron-form-error': 'handleFormError',
       },
       ready: function() {
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.resources.manualAddFormId);

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -131,7 +131,10 @@
           .jsonPrefix;
         this.$.userDeleteForm.request.handleAs = "json";
         this.$.userDeleteForm.request.jsonPrefix = this.resources.jsonPrefix;
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       setRotateKeysAndEnable: function() {
         this.setRotateKeysJsonPrefix();

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -58,7 +58,7 @@
           <div class="second-div">{{item.email}}</div>
           <form is="iron-form" id="userDisableEnableForm" method="post" action="{{resources.revokeToggleUrl}}" class="third-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
             <input type="hidden" name="user_id" value="{{item.id}}">
-            <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+            <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
             <paper-button on-tap="submitForm" class="topLineButton" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>
           </form>
           <paper-icon-button icon="close" title="{{resources.closeText}}" id="{{resources.userDetailsButtonId}}" on-tap="closeDialog"></paper-icon-button>
@@ -81,7 +81,7 @@
           </paper-button>
           <form is="iron-form" id="rotateKeysForm" method="post" action="{{resources.rotateKeysUrl}}" on-iron-form-response="parseRotateResponse" on-iron-form-presubmit="setRotateKeysAndEnable">
             <input type="hidden" name="user_id" value="{{item.id}}">
-            <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+            <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
             <paper-button on-tap="submitForm" class="anchor-button" id="rotateKeysButton" type="submit">
               <iron-icon icon="refresh"></iron-icon> <strong>{{resources.rotateKeysLabel}}</strong>
             </paper-button>
@@ -89,7 +89,7 @@
         </template>
         <form is="iron-form" id="userDeleteForm" method="post" action="{{resources.userDeleteUrl}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
           <input type="hidden" name="user_id" value="{{item.id}}">
-          <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+          <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           <paper-button on-tap="submitForm" class="delete-button" id="userDeleteButton" type="submit">
             <iron-icon icon="delete"></iron-icon>
             <strong>{{resources.userDeleteLabel}}</strong>
@@ -131,6 +131,7 @@
           .jsonPrefix;
         this.$.userDeleteForm.request.handleAs = "json";
         this.$.userDeleteForm.request.jsonPrefix = this.resources.jsonPrefix;
+        this.xsrfToken = document.getElementById('globalXsrf').value;
       },
       setRotateKeysAndEnable: function() {
         this.setRotateKeysJsonPrefix();
@@ -145,9 +146,6 @@
       },
       inviteCodeErrorResponse: function() {
         this.set('loading', false);
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       submitForm: function(e, detail) {
         var elem = e.target;

--- a/ufo/static/userList.html
+++ b/ufo/static/userList.html
@@ -117,7 +117,10 @@
         },
       },
       ready: function() {
-        this.xsrfToken = document.getElementById('globalXsrf').value;
+        var xsrfElement = document.getElementById('globalXsrf');
+        if (xsrfElement) {
+          this.xsrfToken = .value;
+        }
       },
       _limitCharacters: function(text) {
         if (text.length > this.characterLimit) {

--- a/ufo/static/userList.html
+++ b/ufo/static/userList.html
@@ -65,7 +65,7 @@
           <div class="second-div flex">{{_limitCharacters(item.email)}}</div>
           <form is="iron-form" method="post" action="{{resources.revokeToggleUrl}}" loading="{{loading}}" last-response="{{ajaxResponse}}" class="third-div" on-iron-form-response="parseRevokeResponse" on-iron-form-presubmit="enableSpinner">
             <input type="hidden" name="user_id" value="{{item.id}}">
-            <input type="hidden" name="_xsrf_token" value="{{getXsrfToken()}}">
+            <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
             <paper-button on-tap="submitRevokeForm" class="topLineButton leftTextAlign" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>
           </form>
           <user-details-dialog id="detailsHolder" resources="{{resources}}" item="{{item}}"></user-details-dialog>
@@ -116,6 +116,9 @@
           notify: true,
         },
       },
+      ready: function() {
+        this.xsrfToken = document.getElementById('globalXsrf').value;
+      },
       _limitCharacters: function(text) {
         if (text.length > this.characterLimit) {
           return text.substring(0, this.characterLimit) + '...';
@@ -146,9 +149,6 @@
       },
       enableSpinner: function() {
         this.set('loading', true);
-      },
-      getXsrfToken: function() {
-        return document.getElementById('globalXsrf').value;
       },
       _findAncestorMatchingTagnameFromTarget: function(target, tagName) {
         var elem = target;

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -35,6 +35,7 @@
   }
 </style>
 <body class="fullbleed layout vertical">
+  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
   <div>  <!-- Prevent the main-holder from pushing into the header. -->
     <paper-scroll-header-panel>
       <paper-toolbar class="tall" id="main-toolbar">

--- a/ufo/templates/error.html
+++ b/ufo/templates/error.html
@@ -9,6 +9,5 @@
       </div>
     </paper-card>
   </div>
-  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
   <br>
 {% endblock %}

--- a/ufo/templates/landing.html
+++ b/ufo/templates/landing.html
@@ -21,5 +21,4 @@
       </header-container>
     </paper-display-template>
   {% endif %}
-  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
 {% endblock %}

--- a/ufo/templates/login.html
+++ b/ufo/templates/login.html
@@ -15,5 +15,4 @@
       {% endif %}
     </header-container>
   </paper-display-template>
-  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
 {% endblock %}

--- a/ufo/templates/search.html
+++ b/ufo/templates/search.html
@@ -15,5 +15,4 @@
       </server-list>
     </header-container>
   </paper-display-template>
-  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
 {% endblock %}

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -37,7 +37,4 @@
       </settings-configuration>
     </header-container>
   </paper-display-template>
-
-  <!-- Remove this when it's properly in the base.html or provided any other ways. -->
-  <input type="hidden" id="globalXsrf" value="{{xsrf_token()}}">
 {% endblock %}

--- a/web_driver.sh
+++ b/web_driver.sh
@@ -146,7 +146,7 @@ elif [[ "$1" == 'test' ]]; then
     printHelp
     exit 0
   else
-    SERVER_URL="http://ufo-nightly.herokuapp.com"
+    SERVER_URL="https://ufo-nightly.herokuapp.com"
     runUITestsViaSauceLabs
   fi
 else


### PR DESCRIPTION
This moves the xsrf token itself to the base HTML template and to the top of the body so it only needs to be specified in one place then get picked up by custom elements as they load.

We were calling a function to lookup the token as soon as an input element within any custom element was rendered, which may be before the actual token is rendered. For example, the admin dialog may get rendered before the input which will hold the XSRF token. In the admin dialog, that token is attempted to be copied to the local form before the real token is rendered, causing a problem with the entire element rendering. To alleviate this, we now lookup the real XSRF token in the ready function of each custom element, which should not be called until that element is actually ready and would need said token, long after the real token itself has been rendered.

I'm hoping this will help the issue we were seeing with elements not loading correctly when resource dictionaries fail. This may be related since in the cases where the XSRF token wasn't found, the whole element would error out and prevent further loading (thus stopping the resource dictionary potentially). I'll have to run this on nightly to verify.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/193)

<!-- Reviewable:end -->
