### PR TITLE
Forcing the Vulcanized JS File Not to be Cached to Prevent the UI From Becoming Broken

### DIFF
--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -15,6 +15,12 @@ from ufo.handlers import user
 def landing():
   return flask.render_template('landing.html')
 
+@ufo.app.route('/vulcanized')
+@ufo.setup_required
+@auth.login_required
+def vulcanized():
+  return flask.send_file('static/vulcanized.js', cache_timeout=1)
+
 
 # The following imports are commented out since they are already
 # imported above, but are kept here for posterity.

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -6,6 +6,7 @@
   <!-- Include web components script for Polymer to work on firefox. -->
   <script src="{{ url_for('static', filename='bower_components/webcomponentsjs/webcomponents-lite.min.js') }}"></script>
   <link rel="import" href="{{ url_for('static', filename='vulcanized.html') }}" />
+  <script src="{{ url_for('vulcanized') }}"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <link rel="shortcut icon" href="{{ url_for('static', filename='img/favicon.png') }}" type="image/x-icon"/>
   {% block head %}{% endblock %}

--- a/vulcanize.sh
+++ b/vulcanize.sh
@@ -91,7 +91,7 @@ function vulcanizeSingleFileForImports ()
   runInStaticDirAndAssertCmd "rm -fr $VULCANIZED_JS_FILE"
   # This finally vulcanizes all the import statements into one flat file,
   # $VULCANIZED_HTML_FILE, with comments removed and scripts inlined.
-  runInStaticDirAndAssertCmd "${VULCANIZE_COMMAND} $HTML_FILE_TO_VULCANIZE --strip-comments --inline-scripts | ${CRISPER_COMMAND} --html ${VULCANIZED_HTML_FILE} --js ${VULCANIZED_JS_FILE}"
+  runInStaticDirAndAssertCmd "${VULCANIZE_COMMAND} $HTML_FILE_TO_VULCANIZE --strip-comments --inline-scripts | ${CRISPER_COMMAND} --html ${VULCANIZED_HTML_FILE} --js ${VULCANIZED_JS_FILE} --only-split"
   runInStaticDirAndAssertCmd "rm -fr $HTML_FILE_TO_VULCANIZE"
 }
 


### PR DESCRIPTION
This makes the vulcanized JS file into a handler basically so that we can set a specific cache timeout for it. There are other ways to do this with flask, but this was the best way I could find to limit it to this single file. As best as I can tell, the problems seen on nightly and prod come from this file getting cached and executed at a different time than expected, leading things to render improperly. While the caching is not the underlying issue, this change should prevent the problem in the meantime without everyone manually disabling caching in their browser. I'm going to test on nightly after this is submitted to verify this does indeed work.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/196)

<!-- Reviewable:end -->
