### PR TITLE
Allow Vulcanized JS to Get Pulled Down Without Authentication

### DIFF
--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -16,8 +16,6 @@ def landing():
   return flask.render_template('landing.html')
 
 @ufo.app.route('/vulcanized')
-@ufo.setup_required
-@auth.login_required
 def vulcanized():
   return flask.send_file('static/vulcanized.js', cache_timeout=1)
 


### PR DESCRIPTION
I copied the method signature from above and forgot to remove the extra bits, causing the JS not to load on the login page.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/197)

<!-- Reviewable:end -->
