### PR TITLE
Use Quaintous-i18n for i18n Messages in Polymer Elements and Remove Messages from Resource Dictionary

### DIFF
--- a/ufo/services/resource_provider.py
+++ b/ufo/services/resource_provider.py
@@ -8,22 +8,16 @@ from ufo.services import regex
 
 
 def _get_resources():
-  """Get the resources for all UI components including messages for i18n.
+  """Get the resources for all UI components that need to be shared.
 
-    This dictionary of resources is returned as one giant blob for the time
+    This dictionary of resources is returned as one large blob for the time
     being to simplify passing all these parameters to the UI. These could be
-    separated, but the messages for i18n are easier to edit and pickup in a
-    build process as a single file. Those messages will be extracted in the
-    future. The plan for these resources is to limit them to one object on the
-    UI rather than passing them around by utilizing Polymer behaviors
-    https://www.polymer-project.org/1.0/docs/devguide/behaviors . Overall,
-    whether this is one dictionary or multiple, they are set within the session
-    regardless of whether they are used, so they all get loaded during a
-    request, though perhaps not parsed out on the client side.
-
-    TODO(eholder): Refactor the UI to utilize Polymer behaviors to parse this
-    rather than passing it around between components.
-    TODO(eholder): Pull text messages and labels out of this for i18n.
+    separated out again, but they are left as one blob since some are shared
+    by multiple Polymer elements and this blob isn't as large as the i18n
+    messages. Overall, whether this is one dictionary or multiple, they are
+    set within the session regardless of whether they are used, so they all
+    get loaded during a request, though perhaps not parsed out on the client
+    side.
 
     Returns:
       A dict of the resources for UI components.
@@ -32,215 +26,64 @@ def _get_resources():
     'searchPageUrl': flask.url_for('search_page'),
     'searchJsonUrl': flask.url_for('search'),
     'userAddIconUrl': flask.url_for('static', filename='img/add-users.svg'),
-    'addAdminText': 'Add an Admin',
-    'changeAdminPasswordText': 'Change Your Password',
-    'removeAdminText': 'Remove an Admin',
-    'settingsText': 'Settings',
-    'logoutText': 'Log Out',
     'logoutUrl': flask.url_for('logout'),
     'settingsUrl': flask.url_for('setup') + '#settingsDisplayTemplate',
     'listAdminUrl': flask.url_for('admin_list'),
     'addAdminUrl': flask.url_for('add_admin'),
-    'adminEmailLabel': 'Admin Email',
-    'adminPasswordlabel': 'Admin Password',
-    'addAdminSubmitText': 'Add Admin',
-    'adminListGetError': ('Error: Getting the list of admins failed. Try '
-                          'again later.'),
-    'adminExistsError': ('Error: An admin with the specified email already '
-                         'exists.'),
-    'adminAddSuccessText': 'Success! The specified admin was added.',
-    'adminAddFailureText': ('Error: Adding the specified admin failed. Try '
-                            'again later.'),
     'changeAdminPasswordUrl': flask.url_for('change_admin_password'),
-    'changeAdminPasswordInstructions': ('Enter your current password and a ' +
-                                        'new one then submit to update it.'),
-    'changeAdminPasswordOldLabel': 'Current Password',
-    'changeAdminPasswordNewLabel': 'New Password',
-    'changeAdminPasswordSubmitText': 'Update Password',
     'removeAdminUrl': flask.url_for('delete_admin'),
-    'removeAdminInstructions': 'Select an Admin below by email to remove.',
-    'removeAdminSubmitText': 'Remove Admin',
-    'errorTitleText': 'Something is Not Right',
-    'closeText': 'Close',
-    'loginTitleText': 'Please Log In',
     'loginUrl': flask.url_for('login'),
-    'emailLabel': 'Email',
-    'passwordLabel': 'Password',
-    'loginText': 'Login',
     'recaptchaKey': ufo.app.config['RECAPTCHA_SITE_KEY'],
     'setup_url': flask.url_for('setup'),
-    'oauthTitleText': 'Oauth Configuration',
-    'welcomeText': ('Hey there! Welcome to the uProxy for Organizations '
-        'management server! To start, we want to get a bit of information '
-        'from you to get everything set up.'),
-    'googleDomainPromptText': ('First of all, if you are planning on using '
-        'this application with a Google apps domain, we\'re going to need to '
-        'get permission from you to access that. This will be used to keep '
-        'the list of users in your domain in sync with who is allowed to '
-        'access the uProxy servers. The credentials you authorize will be '
-        'shared by any administrators who log into this server. If you do not '
-        'plan on using a Google apps domain with this product, you can just '
-        'go straight to adding users.'),
-    'successSetupText': ('You have already successfully configured this '
-        'deployment! If you want to change the settings, you may do so below. '
-        'Please note: submitting the form even without filling in any '
-        'parameters will cause the previous saved configuration to be lost.'),
-    'domainConfiguredText': ('This site is set up to work with the following '
-        'domain. If that is not correct, please update the configuration.'),
-    'noDomainConfiguredText': ('This site is not set up to use any Google '
-        'apps domain name. All users will need to be manually input.'),
-    'betaWarningText': ('Please keep in mind that this is a much simpler '
-        'version than what you would actually expect to see in a finished '
-        'version of the site. Noteably, this page should include something '
-        'about authenticating yourself in the future (and actually include a '
-        'way to skip).'),
-    'connectYourDomainButtonText': 'Connect to Your Domain',
-    'pasteTheCodeText': ('Once you finish authorizing access, please paste '
-        'the code you receive in the box below.'),
-    'submitButtonText': 'Submit',
     'download_chrome_policy': flask.url_for('download_chrome_policy'),
     'policy_filename': 'chrome_policy.json',
-    'chromePolicyTitleText': 'Chrome Policy',
-    'policyExplanationText': ('Chrome policy is a feature of enterprise '
-        'Google devices which can be used to securely add extra configuration '
-        'to the uProxy frontend. If you use enterprise Google devices through '
-        'Google Apps for Work, you can for example turn on validation for '
-        'invitation links to ensure you are proxying through an endpoint '
-        'controlled by the management console.'),
-    'policyEditText': ('You can adjust the values below in the Management '
-        'Server Settings section and save to update the managed policy json.'
-        'Once you are ready, you can click the download link to get your json '
-        'policy file generated automatically.'),
-    'adminConsoleText': 'Google Admin Console',
-    'policyUploadText': ('To push your managed policy out to your devices, '
-        'visit Google Admin Console at the link above and navigate to the '
-        'uProxy Chrome App/Extension under Device Management -> Chrome '
-        'Management -> App Management. For the App and Extension, select the '
-        'entry listed, then click User settings. From the list of Orgs, '
-        'choose which you want the policy to apply to, then enable Force '
-        'Installation and select Upload Configuration File. Choose the json '
-        'file you just downloaded. You may have to click override to edit '
-        'Force Installation or Configure\'s values. Finally, click Save.'),
-    'downloadText': 'Download',
     'proxyServerAddUrl': flask.url_for('proxyserver_add'),
     'proxyServerAddIconUrl': flask.url_for('static',
                                            filename='img/add-servers.svg'),
     'proxyServerInverseAddIconUrl': flask.url_for(
         'static', filename='img/add-servers-inverse.svg'),
-    'proxyServerAddText': 'Add a Server',
     'proxyServerListId': 'proxyList',
     'proxyServerListUrl': flask.url_for('proxyserver_list'),
     'listLimit': 10,
-    'proxyServerDetailsExpandText': 'Expand Server',
     'proxyServerDetailsButtonId': 'serverDetailsButton',
     'editButtonId': 'serverEditButton',
     'proxyServerDetailsOverlayId': 'serverDetailsOverlay',
-    'editText': 'Edit',
-    'saveText': 'Save',
-    'proxyServerDeleteLabel': 'Delete Server',
     'proxyServerEditUrl': flask.url_for('proxyserver_edit'),
     'proxyServerDeleteUrl': flask.url_for('proxyserver_delete'),
-    'proxyServerSeeAllText': 'See All Servers',
-    'proxyServerTitleText': 'Servers',
-    'nameColumnHeader': 'Name',
-    'ipColumnHeader': 'IP Address',
-    'modfyColumnHeader': 'Modify',
     'proxyServerIconUrl': flask.url_for('static', filename='img/server.svg'),
     'proxyServerAddButtonId': 'addServerButton',
     'proxyServerModalId': 'serverModal',
-    'dismissText': 'Cancel',
-    'confirmText': 'Add Server',
     'textAreaMaxRows': 10,
-    'ipLabel': 'IP Address',
-    'nameLabel': 'Server Name',
-    'sshPrivateKeyLabel': 'SSH Private Key',
-    'hostPublicKeyLabel': 'Host Public Key',
     'ipInput': 'ipInput',
     'nameInput': 'nameInput',
     'sshPrivateKeyInput': 'sshPrivateKeyInput',
     'hostPublicKeyInput': 'hostPublicKeyInput',
-    'ip_address': '',
-    'name': '',
-    'ssh_private_key': '',
-    'host_public_key': '',
-    'sshPrivateKeyText': (
-        'For the private key, please copy the full contents of '
-        'a private key file with the ability to access a proxy '
-        'server. This key is used by the ssh client. '
-        'The beginning of the file should resemble '
-        '"-----BEGIN RSA PRIVATE KEY-----".'),
-    'hostPublicKeyText': (
-        'For the public key, you can usually get this value from '
-        '/etc/ssh/ssh_host_rsa_key.pub of the proxy server. '
-        'This public key is used to authenticate the proxy server.'),
-    'rsaText': ('For now, please be sure to use an RSA key (the text should '
-                'begin with ssh-rsa)'),
-    'settingsTitleText': 'Management Server Settings',
     'getSettingsUrl': flask.url_for('get_settings'),
     'settingsEditUrl': flask.url_for('edit_settings'),
-    'proxyValidityText': 'Enforce Proxy Server Check from Invitation Link',
-    'networkJailText': 'Enforce Network Jail Before Google Login',
     'userAddUrl': flask.url_for('add_user'),
     'userInverseAddIconUrl': flask.url_for(
         'static', filename='img/add-users-inverse.svg'),
-    'userAddText': 'Add Users',
-    'lookAgainText': 'Search Again',
     'userListId': 'userList',
     'userListUrl': flask.url_for('user_list'),
     'revokeToggleUrl': flask.url_for('user_toggle_revoked'),
     'rotateKeysUrl': flask.url_for('user_get_new_key_pair'),
     'inviteCodeUrl': flask.url_for('user_get_invite_code'),
     'userDeleteUrl': flask.url_for('delete_user'),
-    'userDetailsExpandText': 'Expand User',
     'userDetailsButtonId': 'userDetailsButton',
     'userDetailsOverlayId': 'userDetailsOverlay',
-    'inviteCodeNeedServerText': ('Invite codes aren\'t available without any '
-                                 'proxy server configured. Configure a proxy '
-                                 'server to have an invite code created '
-                                 'automatically.'),
-    'inviteCodeLabel': 'Invite Code',
-    'privateKeyLabel': 'SSH Private Key',
-    'publicKeyLabel': 'SSH Public Key',
-    'copyLabel': 'Copy Code',
-    'rotateKeysLabel': 'Create New Code',
-    'userDeleteLabel': 'Delete User',
-    'userSeeAllText': 'See All Users',
-    'userTitleText': 'Users',
-    'emailColumnHeader': 'Email',
-    'accessColumnHeader': 'Access',
     'userIconUrl': flask.url_for('static', filename='img/user.svg'),
     'userAddButtonId': 'addUserButton',
     'userModalId': 'userModal',
-    'addFlowNoResults': 'No results found.',
     'groupAddTabId': 'groupAddTab',
-    'groupAddTab': 'Search for Users in Group',
     'groupAddFormId': 'groupAdd',
-    'groupAddSearchButton': 'Search for Users in Group',
-    'groupAddEmailAddressLabel': 'Group Email Address',
     'groupAddInputName': 'group_key',
-    'groupAddEmailAddressDefinition': ('To add users by group, please provide '
-                                       'a valid group email address or unique '
-                                       'id.'),
     'userAddTabId': 'userAddTab',
-    'userAddTab': 'Search for Individual Users',
     'userAddFormId': 'userAdd',
-    'userAddSearchButton': 'Search for Individual User',
-    'userAddEmailAddressLabel': 'Email Address',
     'userAddInputName': 'user_key',
-    'userAddEmailAddressDefinition': ('To add individual users, please '
-                                      'provide a valid email address or '
-                                      'unique id.'),
     'domainAddTabId': 'domainAddTab',
-    'domainAddTab': 'View All Users in the Domain',
     'domainAddFormId': 'domainAdd',
-    'domainAddSearchButton': 'Search for Users in Domain',
     'manualAddTabId': 'manualAddTab',
-    'manualAddTab': 'Add Manually',
     'manualAddFormId': 'manualAdd',
-    'manualFullNameLabel': 'Full Name',
-    'manualEmailAddressLabel': 'Email Address',
-    'saveMultipleUsersButton': 'Add Users',
-    'saveIndividualUserButton': 'Add User',
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
     'jsonPrefix': ufo.XSSI_PREFIX,
   }

--- a/ufo/static/addItemButton.html
+++ b/ufo/static/addItemButton.html
@@ -1,5 +1,6 @@
 <link rel="import" href="bower_components/iron-icon/iron-icon.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="add-item-button">
   <style is="custom-style">
@@ -14,7 +15,7 @@
         on-tap="openModal"
         id="{{addButtonId}}">
       <iron-icon src="{{inverseAddIconUrl}}"></iron-icon>
-      <strong>{{addText}}</strong>
+      <strong> [[addText]]</strong>
     </paper-button>
   </template>
 
@@ -36,14 +37,22 @@
           case 'proxyServer':
             this.addButtonId = this.resources.proxyServerAddButtonId;
             this.inverseAddIconUrl = this.resources.proxyServerInverseAddIconUrl;
-            this.addText = this.resources.proxyServerAddText;
             this.modalId = this.resources.proxyServerModalId;
             break;
           default:
             this.addButtonId = this.resources.userAddButtonId;
             this.inverseAddIconUrl = this.resources.userInverseAddIconUrl;
-            this.addText = this.resources.userAddText;
             this.modalId = this.resources.userModalId;
+            break;
+        }
+      },
+      attached: function() {
+        switch (this.addType) {
+          case 'proxyServer':
+            this.addText = __i18n__['proxyServerAddText'];
+            break;
+          default:
+            this.addText = __i18n__['userAddText'];
             break;
         }
       },

--- a/ufo/static/addModal.html
+++ b/ufo/static/addModal.html
@@ -1,4 +1,5 @@
 <link rel="import" href="bower_components/paper-dialog/paper-dialog.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="add-modal">
   <style is="custom-style">
@@ -12,7 +13,7 @@
   </style>
   <template>
     <paper-dialog id="{{modalId}}" with-backdrop>
-      <h2 class="title">{{addText}}</h2>
+      <h2 class="title">[[addText]]</h2>
       <div id="contentHolder">
         <template is="dom-if" if="{{isUser}}">
           <user-add-tabs resources="{{resources}}" should-display-with-dialog></user-add-tabs>
@@ -44,13 +45,21 @@
         switch (this.addType) {
           case 'proxyServer':
             this.modalId = this.resources.proxyServerModalId;
-            this.addText = this.resources.proxyServerAddText;
             this.isProxyServer = true;
             break;
           default:
             this.modalId = this.resources.userModalId;
-            this.addText = this.resources.userAddText;
             this.isUser= true;
+            break;
+        }
+      },
+      attached: function() {
+        switch (this.addType) {
+          case 'proxyServer':
+            this.addText = __i18n__['proxyServerAddText'];
+            break;
+          default:
+            this.addText = __i18n__['userAddText'];
             break;
         }
       },

--- a/ufo/static/chromePolicy.html
+++ b/ufo/static/chromePolicy.html
@@ -1,5 +1,6 @@
 <link rel="import" href="bower_components/iron-icon/iron-icon.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="chrome-policy">
   <style is="custom-style">
@@ -12,19 +13,19 @@
   <template>
     <div id="chrome-policy">
       <p>
-        {{resources.policyExplanationText}}
+        [[policyExplanationText]]
       </p>
       <p>
-        {{resources.policyEditText}}
+        [[policyEditText]]
       </p>
 
       <p><a href="https://admin.google.com/AdminHome" class="anchor-no-button" target="_blank">
         <paper-button>
-          <iron-icon icon="open-in-new"></iron-icon> {{resources.adminConsoleText}}
+          <iron-icon icon="open-in-new"></iron-icon> [[adminConsoleText]]
         </paper-button>
       </a></p>
       <p>
-        {{resources.policyUploadText}}
+        [[policyUploadText]]
       </p>
       <div class="buttons">
         <form is="iron-form" id="chromePolicyForm" method="post" action="{{resources.download_chrome_policy}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseChromePolicyResponse">
@@ -33,7 +34,7 @@
             <paper-spinner id="chromePolicySpinner" active$={{loading}}></paper-spinner>
           </template>
           <paper-button class="anchor-button" id="chromePolicyDownloadButton" on-tap="submitChromePolicy" type="submit">
-            <strong><iron-icon icon="file-download"></iron-icon> {{resources.downloadText}}</strong>
+            <strong><iron-icon icon="file-download"></iron-icon> [[downloadText]]</strong>
           </paper-button>
           <a href="data:text/json,{{ajaxResponse}}" download="{{resources.policy_filename}}" hidden id="hiddenChromePolicyButton"></a>
         </form>
@@ -63,6 +64,13 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.policyExplanationText = __i18n__['policyExplanationText'];
+        this.policyEditText = __i18n__['policyEditText'];
+        this.adminConsoleText = __i18n__['adminConsoleText'];
+        this.policyUploadText = __i18n__['policyUploadText'];
+        this.downloadText = __i18n__['downloadText'];
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -6,6 +6,7 @@
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 <link rel="import" href="textarea.html" />
 
 <dom-module id="edit-server-dialog">
@@ -53,8 +54,8 @@
           <iron-icon src="{{resources.proxyServerIconUrl}}" item-icon></iron-icon>
           <div class="first-div"><strong>{{item.name}}</strong></div>
           <div class="second-div">{{item.ip_address}}</div>
-          <paper-button on-tap="switchToServerEdit" class="third-div topLineButton" id="{{resources.editButtonId}}"><strong>{{resources.editText}}</strong></paper-button>
-          <paper-icon-button icon="close" title="{{resources.closeText}}" id="{{resources.proxyServerDetailsButtonId}}" on-tap="closeDialog"></paper-icon-button>
+          <paper-button on-tap="switchToServerEdit" class="third-div topLineButton" id="{{resources.editButtonId}}"><strong>[[editText]]</strong></paper-button>
+          <paper-icon-button icon="close" title="[[closeText]]" id="{{resources.proxyServerDetailsButtonId}}" on-tap="closeDialog"></paper-icon-button>
         </paper-icon-item>
       </paper-listbox>
       <template is="dom-if" if="{{loading}}">
@@ -62,12 +63,12 @@
       </template>
       <div id="rowHolder" class="vertical center-justified layout">
         <form is="iron-form" id="serverEditForm" method="post" action="{{resources.proxyServerEditUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseEditResponse">
-          <paper-input class="editInputFields" disabled label="{{resources.ipLabel}}" type="text" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" value="[[item.ip_address]]" on-keypress="submitIfEnter" id="{{resources.ipInput}}"></paper-input>
-          <paper-input class="editInputFields" disabled label="{{resources.nameLabel}}" type="text" name="name" required value="[[item.name]]" on-keypress="submitIfEnter" id="{{resources.nameInput}}"></paper-input>
+          <paper-input class="editInputFields" disabled label="[[ipLabel]]" type="text" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" value="[[item.ip_address]]" on-keypress="submitIfEnter" id="{{resources.ipInput}}"></paper-input>
+          <paper-input class="editInputFields" disabled label="[[nameLabel]]" type="text" name="name" required value="[[item.name]]" on-keypress="submitIfEnter" id="{{resources.nameInput}}"></paper-input>
           <!-- TODO add the ability to upload files -->
           <paper-input class="editInputFields"
                        disabled
-                       label="[[resources.sshPrivateKeyLabel]]"
+                       label="[[sshPrivateKeyLabel]]"
                        name="ssh_private_key"
                        required
                        max-rows="[[resources.textAreaMaxRows]]"
@@ -79,10 +80,10 @@
                        id="{{resources.sshPrivateKeyInput}}">
           </paper-input>
           <br>
-          <p class="editElements hideElement">{{resources.sshPrivateKeyText}}</p>
+          <p class="editElements hideElement">[[sshPrivateKeyText]]</p>
           <paper-input class="editInputFields"
                        disabled
-                       label="{{resources.hostPublicKeyLabel}}"
+                       label="[[hostPublicKeyLabel]]"
                        type="text"
                        name="host_public_key"
                        required
@@ -93,8 +94,8 @@
                        id="{{resources.hostPublicKeyInput}}">
           </paper-input>
           <br>
-          <p class="editElements hideElement">{{resources.hostPublicKeyText}}</p>
-          <p class="editElements hideElement">{{resources.rsaText}}</p>
+          <p class="editElements hideElement">[[hostPublicKeyText]]</p>
+          <p class="editElements hideElement">[[rsaText]]</p>
           <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           <input type="hidden" name="server_id" value="{{item.id}}">
         </form>
@@ -102,17 +103,17 @@
       <br>
       <div class="buttons">
         <paper-button class="editElements hideElement anchor-button" on-tap="cancelServerEdit">
-        <strong>{{resources.dismissText}}</strong>
+        <strong>[[dismissText]]</strong>
         </paper-button>
         <paper-button class="editElements hideElement anchor-button" on-tap="submitEditForm" id="serverEditSubmitButton">
-        <strong>{{resources.saveText}}</strong>
+        <strong>[[saveText]]</strong>
         </paper-button>
         <form is="iron-form" id="serverDeleteForm" method="post" action="{{resources.proxyServerDeleteUrl}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
           <input type="hidden" name="server_id" value="{{item.id}}">
           <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           <paper-button on-tap="submitForm" class="delete-button" id="serverDeleteButton" type="submit">
             <iron-icon icon="delete"></iron-icon>
-            <strong>{{resources.proxyServerDeleteLabel}}</strong>
+            <strong>[[proxyServerDeleteLabel]]</strong>
           </paper-button>
         </form>
       </div>
@@ -153,6 +154,20 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.editText = __i18n__['editText'];
+        this.closeText = __i18n__['closeText'];
+        this.ipLabel = __i18n__['ipLabel'];
+        this.nameLabel = __i18n__['nameLabel'];
+        this.sshPrivateKeyLabel = __i18n__['sshPrivateKeyLabel'];
+        this.sshPrivateKeyText = __i18n__['sshPrivateKeyText'];
+        this.hostPublicKeyLabel = __i18n__['hostPublicKeyLabel'];
+        this.hostPublicKeyText = __i18n__['hostPublicKeyText'];
+        this.rsaText = __i18n__['rsaText'];
+        this.dismissText = __i18n__['dismissText'];
+        this.saveText = __i18n__['saveText'];
+        this.proxyServerDeleteLabel = __i18n__['proxyServerDeleteLabel'];
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/errorNotification.html
+++ b/ufo/static/errorNotification.html
@@ -1,5 +1,6 @@
 <link rel="import" href="bower_components/polymer/polymer.html">
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="error-notification">
   <style is="custom-style">
@@ -67,11 +68,11 @@
           <div id="right">
             <div id="errorDetail">
               <div id="errorTitle">
-                {{resources.errorTitleText}}
+                [[errorTitleText]]
               </div>
               <br>
               <div id="errorMessage">
-                {{errorMessage}}
+                [[errorMessage]]
               </div>
             </div>
           </div>
@@ -79,7 +80,7 @@
             <paper-button id="errorNotificationCloseButton"
                           class="custom"
                           on-transitionend="closeErrorNotification">
-              <strong>{{resources.closeText}}</strong>
+              <strong>[[closeText]]</strong>
             </paper-button>
           </div>
         </div>
@@ -98,6 +99,10 @@
       },
       listeners: {
         'ApplicationError': 'showErrorNotification',
+      },
+      attached: function() {
+        this.errorTitleText = __i18n__['errorTitleText'];
+        this.closeText = __i18n__['closeText'];
       },
       showErrorNotification: function(event, detail) {
         this.errorCode = detail.code;

--- a/ufo/static/headerContainer.html
+++ b/ufo/static/headerContainer.html
@@ -1,6 +1,7 @@
 <link rel="import" href="bower_components/iron-ajax/iron-ajax.html" />
 <link rel="import" href="bower_components/paper-material/paper-material.html" />
 <link rel="import" href="bower_components/paper-toolbar/paper-toolbar.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="header-container">
   <style is="custom-style">
@@ -46,25 +47,25 @@
           value: '',
         },
       },
-      ready: function() {
+      attached: function() {
         switch (this.headerType) {
           case 'chromePolicy':
-            this.titleText = this.resources.chromePolicyTitleText;
+            this.titleText = __i18n__['chromePolicyTitleText'];
             break;
           case 'login':
-            this.titleText = this.resources.loginTitleText;
+            this.titleText = __i18n__['loginTitleText'];
             break;
           case 'oauth':
-            this.titleText = this.resources.oauthTitleText;
+            this.titleText = __i18n__['oauthTitleText'];
             break;
           case 'proxyServer':
-            this.titleText = this.resources.proxyServerTitleText;
+            this.titleText = __i18n__['proxyServerTitleText'];
             break;
           case 'settings':
-            this.titleText = this.resources.settingsTitleText;
+            this.titleText = __i18n__['settingsTitleText'];
             break;
           default:
-            this.titleText = this.resources.userTitleText;
+            this.titleText = __i18n__['userTitleText'];
             break;
         }
       },

--- a/ufo/static/leftIconContainer.html
+++ b/ufo/static/leftIconContainer.html
@@ -1,4 +1,5 @@
 <link rel="import" href="bower_components/polymer/polymer.html">
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="left-icon-container">
   <style is="custom-style">
@@ -62,12 +63,20 @@
       ready: function() {
         switch (this.addType) {
           case 'proxyServer':
-            this.addText = this.resources.proxyServerAddText;
             this.addIconUrl = this.resources.proxyServerAddIconUrl;
             break;
           default:
-            this.addText = this.resources.userAddText;
             this.addIconUrl = this.resources.userAddIconUrl;
+            break;
+        }
+      },
+      attached: function() {
+        switch (this.addType) {
+          case 'proxyServer':
+            this.addText = __i18n__['proxyServerAddText'];
+            break;
+          default:
+            this.addText = __i18n__['userAddText'];
             break;
         }
       },

--- a/ufo/static/loginForm.html
+++ b/ufo/static/loginForm.html
@@ -1,5 +1,6 @@
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
 <link rel="import" href="bower_components/paper-input/paper-input.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="login-form">
   <style is="custom-style">
@@ -19,8 +20,8 @@
   </style>
   <template>
     <form id="loginForm" method="POST">
-      <paper-input label="{{resources.emailLabel}}" id="email" name="email" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter"></paper-input>
-      <paper-input type="password" label="{{resources.passwordLabel}}" id="password" name="password" required on-keypress="submitIfEnter"></paper-input>
+      <paper-input label="[[emailLabel]]" id="email" name="email" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter"></paper-input>
+      <paper-input type="password" label="[[passwordLabel]]" id="password" name="password" required on-keypress="submitIfEnter"></paper-input>
 
       <template is="dom-if" if="{{shouldShowRecaptcha}}">
         <script src='//www.google.com/recaptcha/api.js'></script>
@@ -34,7 +35,7 @@
     </form>
     <div class="buttons">
       <paper-button on-tap="submitLoginForm" class="anchor-button" type="submit" id="signIn">
-        <strong>{{resources.loginText}}</strong>
+        <strong>[[loginText]]</strong>
       </paper-button>
     </div>
   </template>
@@ -65,6 +66,9 @@
           this.querySelector('#recaptchaDiv')
             .setAttribute('data-sitekey', this.resources.recaptchaKey);
         }
+        this.emailLabel = __i18n__['emailLabel'];
+        this.passwordLabel = __i18n__['passwordLabel'];
+        this.loginText = __i18n__['loginText'];
       },
       submitLoginForm: function() {
         this.querySelector('#loginForm').submit();

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -2,6 +2,7 @@
 <link rel="import" href="bower_components/paper-input/paper-input.html" />
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="oauth-configuration">
   <style is="custom-style">
@@ -26,45 +27,45 @@
     <!-- TODO: Make a clear way to say you do not want to use Google apps. -->
       <template is="dom-if" if="{{!configuration.config.is_configured}}">
         <p>
-          {{resources.welcomeText}}
+          [[welcomeText]]
         </p>
         <p>
-          {{resources.googleDomainPromptText}}
+          [[googleDomainPromptText]]
         </p>
       </template>
 
       <template is="dom-if" if="{{configuration.config.is_configured}}">
         <p>
-          {{resources.successSetupText}}
+          [[successSetupText]]
         </p>
 
         <template is="dom-if" if="{{isDomainConfigured(configuration.config)}}">
           <p>
-            {{resources.domainConfiguredText}} <strong>{{configuration.config.domain}}</strong>
+            [[domainConfiguredText]] <strong>{{configuration.config.domain}}</strong>
           </p>
         </template>
 
         <template is="dom-if" if="{{!isDomainConfigured(configuration.config)}}">
           <p>
-            {{resources.noDomainConfiguredText}}
+            [[noDomainConfiguredText]]
           </p>
         </template>
       </template>
 
         <p>
-          {{resources.betaWarningText}}
+          [[betaWarningText]]
         </p>
 
         <p>
           <a class="anchor-no-button" href="{{configuration.oauth_url}}" target="_blank">
             <paper-button>
-              <iron-icon icon="open-in-new"></iron-icon> {{resources.connectYourDomainButtonText}}
+              <iron-icon icon="open-in-new"></iron-icon> [[connectYourDomainButtonText]]
             </paper-button>
           </a>
         </p>
 
          <p>
-           {{resources.pasteTheCodeText}}
+           [[pasteTheCodeText]]
          </p>
 
       <!-- TODO make this form be more useful -->
@@ -75,7 +76,7 @@
           <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
           <div class="buttons">
             <paper-button on-tap="submitOauth" class="form-submit-button anchor-button" type="submit">
-              <strong>{{resources.submitButtonText}}</strong>
+              <strong>[[submitButtonText]]</strong>
             </paper-button>
           </div>
         </form>
@@ -84,12 +85,12 @@
         <form id="oauthConfigurationForm" method="post" action="{{resources.setup_url}}">
           <paper-input label="Domain" name="domain" on-keypress="submitIfEnter"></paper-input>
           <paper-input label="OAuth Code" name="oauth_code" on-keypress="submitIfEnter"></paper-input>
-          <paper-input label="{{resources.adminEmailLabel}}" required name="admin_email"></paper-input>
-          <paper-input label="{{resources.adminPasswordlabel}}" required name="admin_password" on-keypress="submitIfEnter"></paper-input>
+          <paper-input label="[[adminEmailLabel]]" required name="admin_email"></paper-input>
+          <paper-input label="[[adminPasswordlabel]]" required name="admin_password" on-keypress="submitIfEnter"></paper-input>
           <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
           <div class="buttons">
             <paper-button on-tap="submitOauth" class="form-submit-button anchor-button" type="submit">
-              <strong>{{resources.submitButtonText}}</strong>
+              <strong>[[submitButtonText]]</strong>
             </paper-button>
           </div>
         </form>
@@ -114,6 +115,19 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.welcomeText = __i18n__['welcomeText'];
+        this.googleDomainPromptText = __i18n__['googleDomainPromptText'];
+        this.successSetupText = __i18n__['successSetupText'];
+        this.domainConfiguredText = __i18n__['domainConfiguredText'];
+        this.noDomainConfiguredText = __i18n__['noDomainConfiguredText'];
+        this.betaWarningText = __i18n__['betaWarningText'];
+        this.connectYourDomainButtonText = __i18n__['connectYourDomainButtonText'];
+        this.pasteTheCodeText = __i18n__['pasteTheCodeText'];
+        this.submitButtonText = __i18n__['submitButtonText'];
+        this.adminEmailLabel = __i18n__['adminEmailLabel'];
+        this.adminPasswordlabel = __i18n__['adminPasswordlabel'];
       },
       isDomainConfigured: function(config) {
         return config.domain && config.credentials;

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -3,6 +3,7 @@
 <link rel="import" href="bower_components/paper-dialog-scrollable/paper-dialog-scrollable.html" />
 <link rel="import" href="bower_components/paper-input/paper-input.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="server-add-form">
   <style is="custom-style">
@@ -21,38 +22,37 @@
         <paper-spinner id="serverSpinner" class="absolutePositionSpinner" active$={{loading}}></paper-spinner>
       </template>
       <form is="iron-form" id="serverAddForm" method="post" action="{{resources.proxyServerAddUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parsePostResponse">
-        <paper-input label="{{resources.ipLabel}}" type="text" id="{{resources.ipInput}}" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" on-keypress="submitIfEnter">{{resources.ip_address}}</paper-input>
-        <paper-input label="{{resources.nameLabel}}" type="text" id="{{resources.nameInput}}" name="name" required on-keypress="submitIfEnter">{{resources.name}}</paper-input>
+        <paper-input label="[[ipLabel]]" type="text" id="{{resources.ipInput}}" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" on-keypress="submitIfEnter"></paper-input>
+        <paper-input label="[[nameLabel]]" type="text" id="{{resources.nameInput}}" name="name" required on-keypress="submitIfEnter"></paper-input>
         <!-- TODO add the ability to upload files -->
-        <ufo-textarea label="{{resources.sshPrivateKeyLabel}}"
+        <ufo-textarea label="[[sshPrivateKeyLabel]]"
                       id="{{resources.sshPrivateKeyInput}}"
                       name="ssh_private_key"
                       required max-rows="{{resources.textAreaMaxRows}}"
                       pattern="{{resources.regexes.privateKeyPattern}}"
-                      error-message="{{resources.regexes.privateKeyError}}"
-                      value="{{resources.ssh_private_key}}">
+                      error-message="{{resources.regexes.privateKeyError}}">
         </ufo-textarea>
         <br>
-        <p>{{resources.sshPrivateKeyText}}</p>
-        <paper-input label="{{resources.hostPublicKeyLabel}}"
+        <p>[[sshPrivateKeyText]]</p>
+        <paper-input label="[[hostPublicKeyLabel]]"
                      type="text"
                      id="{{resources.hostPublicKeyInput}}"
                      name="host_public_key"
                      required pattern="{{resources.regexes.publicKeyPattern}}"
                      error-message="{{resources.regexes.publicKeyError}}"
-                     on-keypress="submitIfEnter">{{resources.host_public_key}}
+                     on-keypress="submitIfEnter">
         </paper-input>
         <br>
-        <p>{{resources.hostPublicKeyText}}</p>
-        <p>{{resources.rsaText}}</p>
+        <p>[[hostPublicKeyText]]</p>
+        <p>[[rsaText]]</p>
         <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
       </form>
       <div class="buttons">
         <paper-button class="anchor-button" dialog-dismiss on-tap="resetForm">
-        <strong>{{resources.dismissText}}</strong>
+        <strong>[[dismissText]]</strong>
         </paper-button>
         <paper-button class="anchor-button" id="serverAddSubmitButton" autofocus on-tap="submitPostForm">
-        <strong>{{resources.confirmText}}</strong>
+        <strong>[[confirmText]]</strong>
         </paper-button>
       </div>
     </paper-dialog-scrollable>
@@ -82,6 +82,17 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.ipLabel = __i18n__['ipLabel'];
+        this.nameLabel = __i18n__['nameLabel'];
+        this.sshPrivateKeyLabel = __i18n__['sshPrivateKeyLabel'];
+        this.sshPrivateKeyText = __i18n__['sshPrivateKeyText'];
+        this.hostPublicKeyLabel = __i18n__['hostPublicKeyLabel'];
+        this.hostPublicKeyText = __i18n__['hostPublicKeyText'];
+        this.rsaText = __i18n__['rsaText'];
+        this.dismissText = __i18n__['dismissText'];
+        this.confirmText = __i18n__['confirmText'];
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/serverList.html
+++ b/ufo/static/serverList.html
@@ -2,8 +2,9 @@
 <link rel="import" href="bower_components/iron-form/iron-form.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
-<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />>
+<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="server-list">
   <style is="custom-style">
@@ -53,9 +54,9 @@
     <paper-listbox>
       <paper-icon-item id="columnHeader" class="horizontal layout">
         <iron-icon src="{{resources.proxyServerIconUrl}}" class="noDisplay" item-icon></iron-icon>
-        <div class="first-div"><strong>{{resources.nameColumnHeader}}</strong></div>
-        <div class="second-div flex"><strong>{{resources.ipColumnHeader}}</strong></div>
-        <div class="third-div"><strong>{{resources.modfyColumnHeader}}</strong></div>
+        <div class="first-div"><strong>[[nameColumnHeader]]</strong></div>
+        <div class="second-div flex"><strong>[[ipColumnHeader]]</strong></div>
+        <div class="third-div"><strong>[[modifyColumnHeader]]</strong></div>
         <paper-icon-button icon="expand-more" class="noDisplay"></paper-icon-button>
       </paper-icon-item>
       <template is="dom-repeat" items="{{_limitResults(ajaxResponse.items, isShowingAll)}}" id="repeatToRerender">
@@ -63,15 +64,15 @@
           <iron-icon src="{{resources.proxyServerIconUrl}}" item-icon></iron-icon>
           <div class="first-div"><strong>{{item.name}}</strong></div>
           <div class="second-div flex">{{item.ip_address}}</div>
-          <paper-button on-tap="openServerEdit" class="third-div topLineButton leftTextAlign" id="{{resources.editButtonId}}"><strong>{{resources.editText}}</strong></paper-button>
+          <paper-button on-tap="openServerEdit" class="third-div topLineButton leftTextAlign" id="{{resources.editButtonId}}"><strong>[[editText]]</strong></paper-button>
           <edit-server-dialog id="detailsHolder" resources="{{resources}}" item="{{item}}"></edit-server-dialog>
-          <paper-icon-button icon="expand-more" title="{{resources.proxyServerDetailsExpandText}}" id="{{resources.proxyServerDetailsButtonId}}"></paper-icon-button>
+          <paper-icon-button icon="expand-more" title="[[proxyServerDetailsExpandText]]" id="{{resources.proxyServerDetailsButtonId}}"></paper-icon-button>
         </paper-icon-item>
       </template>
       <template is="dom-if" if="[[_hasMoreToShow(ajaxResponse.items, isShowingAll)]]">
         <paper-item id="showMore" class="horizontal layout start-justified">
           <paper-button class="see-all-button" on-tap="_flipShowingAll">
-          {{resources.proxyServerSeeAllText}}
+          [[proxyServerSeeAllText]]
           </paper-button>
         </paper-item>
       </template>
@@ -111,6 +112,14 @@
           value: false,
           notify: true,
         },
+      },
+      attached: function() {
+        this.nameColumnHeader = __i18n__['nameColumnHeader'];
+        this.ipColumnHeader = __i18n__['ipColumnHeader'];
+        this.modifyColumnHeader = __i18n__['modifyColumnHeader'];
+        this.editText = __i18n__['editText'];
+        this.proxyServerDetailsExpandText = __i18n__['proxyServerDetailsExpandText'];
+        this.proxyServerSeeAllText = __i18n__['proxyServerSeeAllText'];
       },
       _limitCharacters: function(text) {
         if (text.length > this.characterLimit) {

--- a/ufo/static/settingsConfiguration.html
+++ b/ufo/static/settingsConfiguration.html
@@ -2,6 +2,7 @@
 <link rel="import" href="bower_components/iron-form/iron-form.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="settings-configuration">
   <style is="custom-style">
@@ -22,9 +23,9 @@
       json-prefix="{{resources.jsonPrefix}}">
     </iron-ajax>
     <form is="iron-form" id="policyConfigForm" method="post" action="{{resources.settingsEditUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseConfigResponse">
-      <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="{{resources.proxyValidityText}}" checked$={{ajaxResponse.enforce_proxy_server_validity}}></ufo-toggle-input>
+      <ufo-toggle-input input-name="enforce_proxy_server_validity" button-text="[[proxyValidityText]]" checked$={{ajaxResponse.enforce_proxy_server_validity}}></ufo-toggle-input>
       <br>
-      <ufo-toggle-input input-name="enforce_network_jail" button-text="{{resources.networkJailText}}" checked$={{ajaxResponse.enforce_network_jail}}></ufo-toggle-input>
+      <ufo-toggle-input input-name="enforce_network_jail" button-text="[[networkJailText]]" checked$={{ajaxResponse.enforce_network_jail}}></ufo-toggle-input>
       <br>
       <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
       <div class="buttons">
@@ -32,7 +33,7 @@
           <paper-spinner id="settingsSpinner" active$={{loading}}></paper-spinner>
         </template>
         <paper-button class="anchor-button" id="saveSettingsButton" on-tap="submitConfig" type="submit">
-          <strong>{{resources.saveText}}</strong>
+          <strong>[[saveText]]</strong>
         </paper-button>
       </div>
     </form>
@@ -61,6 +62,11 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.proxyValidityText = __i18n__['proxyValidityText'];
+        this.networkJailText = __i18n__['networkJailText'];
+        this.saveText = __i18n__['saveText'];
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -10,6 +10,7 @@
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-menu/paper-menu.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="ufo-dropdown-menu">
   <style is="custom-style">
@@ -56,20 +57,20 @@
       <paper-listbox>
         <paper-icon-item class="dropdown-button" id="addAdminButton" on-tap="flipToAddAdminFlow">
           <iron-icon class="dropdown-icon" src="{{resources.userAddIconUrl}}" item-icon></iron-icon>
-          <strong>{{resources.addAdminText}}</strong>
+          <strong>[[addAdminText]]</strong>
         </paper-icon-item>
         <paper-icon-item class="dropdown-button" id="changeAdminPasswordButton" on-tap="flipToChangeAdminPasswordFlow">
           <iron-icon class="dropdown-icon" icon="editor:mode-edit" item-icon></iron-icon>
-          <strong>{{resources.changeAdminPasswordText}}</strong>
+          <strong>[[changeAdminPasswordText]]</strong>
         </paper-icon-item>
         <paper-icon-item class="dropdown-button" id="removeAdminButton" on-tap="flipToRemoveAdminFlow">
           <iron-icon class="dropdown-icon" icon="remove-circle-outline" item-icon></iron-icon>
-          <strong>{{resources.removeAdminText}}</strong>
+          <strong>[[removeAdminText]]</strong>
         </paper-icon-item>
         <a href="{{resources.settingsUrl}}" id="settingsAnchor">
           <paper-icon-item class="dropdown-button">
             <iron-icon class="dropdown-icon" icon="settings" item-icon></iron-icon>
-            <strong>{{resources.settingsText}}</strong>
+            <strong>[[settingsText]]</strong>
           </paper-icon-item>
         </a>
         <paper-icon-item class="dropdown-button">
@@ -77,7 +78,7 @@
           <form id="logoutForm" method="post" action="{{resources.logoutUrl}}">
             <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
             <paper-button type="submit" on-tap="submitLogoutForm" id="logoutButton">
-              <strong>{{resources.logoutText}}</strong>
+              <strong>[[logoutText]]</strong>
             </paper-button>
           </form>
         </paper-icon-item>
@@ -95,13 +96,13 @@
         <p id="addAdminResponseStatus">{{responseStatus}}</p>
       </template>
       <form is="iron-form" id="addAdminForm" method="post" action="{{resources.addAdminUrl}}" on-iron-form-response="parseAddAdminResponse" on-iron-form-presubmit="enableSpinner">
-        <paper-input label="{{resources.adminEmailLabel}}" id="paperAdminEmail" name="paperEmail" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter"></paper-input>
-        <paper-input label="{{resources.adminPasswordlabel}}" id="paperAdminPassword" name="paperPassword" required on-keypress="submitIfEnter"></paper-input>
+        <paper-input label="[[adminEmailLabel]]" id="paperAdminEmail" name="paperEmail" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter"></paper-input>
+        <paper-input label="[[adminPasswordLabel]]" id="paperAdminPassword" name="paperPassword" required on-keypress="submitIfEnter"></paper-input>
         <input type="hidden" name="admin_email" id="jsonEmail" value="" />
         <input type="hidden" name="admin_password" id="jsonPassword" value="" />
         <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}" />
         <paper-button on-tap="submitAddAdminForm" class="floatToTheRight anchor-button" id="adminFormSubmitButton" type="submit">
-          <strong>{{resources.addAdminSubmitText}}</strong>
+          <strong>[[addAdminSubmitText]]</strong>
         </paper-button>
       </form>
       <p></p>
@@ -113,19 +114,19 @@
       <paper-button on-tap="flipToDropdownFlowFromChangeAdminPassword" class="header">
         <iron-icon icon="arrow-back" item-icon></iron-icon>
       </paper-button>
-      {{resources.changeAdminPasswordInstructions}}
+      [[changeAdminPasswordInstructions]]
       <paper-button class="floatToTheRight" on-tap="exitAll">
         <iron-icon icon="close" item-icon></iron-icon>
       </paper-button>
       <form is="iron-form" id="changeAdminPasswordForm" method="post" action="{{resources.changeAdminPasswordUrl}}" on-iron-form-response="parseChangeAdminPasswordResponse" on-iron-form-presubmit="enableSpinner">
-        <paper-input label="{{resources.changeAdminPasswordOldLabel}}" id="paperAdminOldPassword" name="paperAdminOldPassword" required on-keypress="submitIfEnter"></paper-input>
-        <paper-input label="{{resources.changeAdminPasswordNewLabel}}" id="paperAdminNewPassword" name="paperAdminNewPassword" required on-keypress="submitIfEnter"></paper-input>
+        <paper-input label="[[changeAdminPasswordOldLabel]]" id="paperAdminOldPassword" name="paperAdminOldPassword" required on-keypress="submitIfEnter"></paper-input>
+        <paper-input label="[[changeAdminPasswordNewLabel]]" id="paperAdminNewPassword" name="paperAdminNewPassword" required on-keypress="submitIfEnter"></paper-input>
         <input type="hidden" name="old_password" id="jsonOldPassword" value="" />
         <input type="hidden" name="new_password" id="jsonNewPassword" value="" />
         <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
       </form>
       <div class="buttons">
-        <paper-button on-tap="submitChangeAdminPasswordForm" class="anchor-button" id="changeAdminPasswordSubmitButton" type="submit"><strong>{{resources.changeAdminPasswordSubmitText}}</strong></paper-button>
+        <paper-button on-tap="submitChangeAdminPasswordForm" class="anchor-button" id="changeAdminPasswordSubmitButton" type="submit"><strong>[[changeAdminPasswordSubmitText]]</strong></paper-button>
       </div>
     </paper-dialog>
 
@@ -133,7 +134,7 @@
       <paper-button on-tap="flipToDropdownFlowFromRemoveAdmin" class="header">
         <iron-icon icon="arrow-back" item-icon></iron-icon>
       </paper-button>
-      {{resources.removeAdminInstructions}}
+      [[removeAdminInstructions]]
       <paper-button class="floatToTheRight" on-tap="exitAll">
         <iron-icon icon="close" item-icon></iron-icon>
       </paper-button>
@@ -160,7 +161,7 @@
         </form>
       </paper-dialog-scrollable>
       <div class="buttons">
-        <paper-button on-tap="submitRemoveAdminForm" class="anchor-button" id="removeAdminSubmitButton" type="submit"><strong>{{resources.removeAdminSubmitText}}</strong></paper-button>
+        <paper-button on-tap="submitRemoveAdminForm" class="anchor-button" id="removeAdminSubmitButton" type="submit"><strong>[[removeAdminSubmitText]]</strong></paper-button>
       </div>
     </paper-dialog>
   </template>
@@ -209,6 +210,22 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.addAdminText = __i18n__['addAdminText'];
+        this.changeAdminPasswordText = __i18n__['changeAdminPasswordText'];
+        this.removeAdminText = __i18n__['removeAdminText'];
+        this.settingsText = __i18n__['settingsText'];
+        this.logoutText = __i18n__['logoutText'];
+        this.adminEmailLabel = __i18n__['adminEmailLabel'];
+        this.adminPasswordLabel = __i18n__['adminPasswordLabel'];
+        this.addAdminSubmitText = __i18n__['addAdminSubmitText'];
+        this.changeAdminPasswordInstructions = __i18n__['changeAdminPasswordInstructions'];
+        this.changeAdminPasswordOldLabel = __i18n__['changeAdminPasswordOldLabel'];
+        this.changeAdminPasswordNewLabel = __i18n__['changeAdminPasswordNewLabel'];
+        this.changeAdminPasswordSubmitText = __i18n__['changeAdminPasswordSubmitText'];
+        this.removeAdminInstructions = __i18n__['removeAdminInstructions'];
+        this.removeAdminSubmitText = __i18n__['removeAdminSubmitText'];
       },
       openMenu: function() {
         this.$.ufoDropdownMenu.open();
@@ -340,16 +357,16 @@
           var found = this._findEmailInAdminList(admins, email);
           if (found) {
             this.set('showResponseStatus', true);
-            this.set('responseStatus', this.resources.adminAddSuccessText);
+            this.set('responseStatus', __i18n__['adminAddSuccessText']);
             this.set('ajaxResponse', this.$.addAdminForm.request.lastResponse);
             this.resetAddAdminForm();
           } else {
             this.set('showResponseStatus', true);
-            this.set('responseStatus', this.resources.adminAddFailureText);
+            this.set('responseStatus', __i18n__['adminAddFailureText']);
           }
         } else {
           this.set('showResponseStatus', true);
-          this.set('responseStatus', this.resources.adminListGetError);
+          this.set('responseStatus', __i18n__['adminListGetError']);
         }
         this.set('loading', false);
       },

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -5,6 +5,7 @@
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
 <link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="user-add-form">
   <style is="custom-style">
@@ -41,7 +42,7 @@
               <paper-listbox>
               <template is="dom-if" if="[[!areAnyUsersFound()]]">
                 <paper-item id="noResultsItem" class="horizontal layout">
-                  <span class="flex"><strong>{{resources.addFlowNoResults}}</strong></span>
+                  <span class="flex"><strong>[[addFlowNoResults]]</strong></span>
                 </paper-item>
               </template>
                 <template is="dom-repeat" items="[[lastResponse.directory_users]]">
@@ -63,7 +64,7 @@
             <paper-listbox>
               <template is="dom-if" if="[[!areAnyUsersFound()]]">
                 <paper-item id="noResultsItem" class="horizontal layout">
-                  <span class="flex"><strong>{{resources.addFlowNoResults}}</strong></span>
+                  <span class="flex"><strong>[[addFlowNoResults]]</strong></span>
                 </paper-item>
               </template>
               <template is="dom-repeat" items="[[lastResponse.directory_users]]">
@@ -79,12 +80,12 @@
             <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           </form>
         </template>
-        <paper-button on-tap="resetForms" class="anchor-button addTopMargin"><strong>{{resources.lookAgainText}}</strong></paper-button>
+        <paper-button on-tap="resetForms" class="anchor-button addTopMargin"><strong>[[lookAgainText]]</strong></paper-button>
       </template>
     </div>
     <div class="buttons">
       <paper-button class="anchor-button" dialog-dismiss on-tap="resetForms">
-      <strong>{{resources.dismissText}}</strong>
+      <strong>[[dismissText]]</strong>
       </paper-button>
       <paper-button class="anchor-button" autofocus on-tap="submitPostForm">
       <strong>{{saveButton}}</strong>
@@ -166,6 +167,11 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.addFlowNoResults = __i18n__['addFlowNoResults'];
+        this.lookAgainText = __i18n__['lookAgainText'];
+        this.dismissText = __i18n__['dismissText'];
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.formId);

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -4,6 +4,7 @@
 <link rel="import" href="bower_components/paper-input/paper-input.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
 <link rel="import" href="bower_components/paper-tabs/paper-tabs.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="user-add-tabs">
   <style is="custom-style">
@@ -26,10 +27,10 @@
     <!--Portion for finding users via group, individual, domain, or manual
     specification. -->
     <paper-tabs id="tabs" selected="{{ selected }}">
-      <paper-tab id="{{resources.groupAddTabId}}">{{resources.groupAddTab}}</paper-tab>
-      <paper-tab id="{{resources.userAddTabId}}">{{resources.userAddTab}}</paper-tab>
-      <paper-tab id="{{resources.domainAddTabId}}">{{resources.domainAddTab}}</paper-tab>
-      <paper-tab id="{{resources.manualAddTabId}}">{{resources.manualAddTab}}</paper-tab>
+      <paper-tab id="{{resources.groupAddTabId}}">[[groupAddTab]]</paper-tab>
+      <paper-tab id="{{resources.userAddTabId}}">[[userAddTab]]</paper-tab>
+      <paper-tab id="{{resources.domainAddTabId}}">[[domainAddTab]]</paper-tab>
+      <paper-tab id="{{resources.manualAddTabId}}">[[manualAddTab]]</paper-tab>
     </paper-tabs>
 
     <div id="ironPagesHolder">
@@ -38,37 +39,37 @@
           resources="{{resources}}"
           should-display-with-dialog$="[[shouldDisplayWithDialog]]"
           form-id="{{resources.groupAddFormId}}"
-          save-button="{{resources.saveMultipleUsersButton}}"
-          search-button="{{resources.groupAddSearchButton}}"
-          email-label="{{resources.groupAddEmailAddressLabel}}"
+          save-button="[[saveMultipleUsersButton]]"
+          search-button="[[groupAddSearchButton]]"
+          email-label="[[groupAddEmailAddressLabel]]"
           input-name="{{resources.groupAddInputName}}"
-          input-definition="{{resources.groupAddEmailAddressDefinition}}">
+          input-definition="[[groupAddEmailAddressDefinition]]">
         </user-add-form>
         <user-add-form
           resources="{{resources}}"
           should-display-with-dialog$="[[shouldDisplayWithDialog]]"
           form-id="{{resources.userAddFormId}}"
-          save-button="{{resources.saveIndividualUserButton}}"
-          search-button="{{resources.userAddSearchButton}}"
-          email-label="{{resources.userAddEmailAddressLabel}}"
+          save-button="[[saveIndividualUserButton]]"
+          search-button="[[userAddSearchButton]]"
+          email-label="[[userAddEmailAddressLabel]]"
           input-name="{{resources.userAddInputName}}"
-          input-definition="{{resources.userAddEmailAddressDefinition}}">
+          input-definition="[[userAddEmailAddressDefinition]]">
         </user-add-form>
         <user-add-form
           resources="{{resources}}"
           should-display-with-dialog$="[[shouldDisplayWithDialog]]"
           form-id="{{resources.domainAddFormId}}"
-          save-button="{{resources.saveMultipleUsersButton}}"
-          search-button="{{resources.domainAddSearchButton}}">
+          save-button="[[saveMultipleUsersButton]]"
+          search-button="[[domainAddSearchButton]]">
         </user-add-form>
         <div>
           <template is="dom-if" if="{{loading}}">
             <paper-spinner id="manualAddSpinner" class="absolutePositionSpinner" active$={{loading}}></paper-spinner>
           </template>
           <form is="iron-form" id="{{resources.manualAddFormId}}" method="post" action="{{resources.userAddUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parsePostResponse">
-            <paper-input label="{{resources.manualFullNameLabel}}" type="textbox" name="name" value="" id="manualUserName" required on-keypress="submitIfEnter">
+            <paper-input label="[[manualFullNameLabel]]" type="textbox" name="name" value="" id="manualUserName" required on-keypress="submitIfEnter">
             </paper-input>
-            <paper-input label="{{resources.manualEmailAddressLabel}}" type="email" name="email" value="" id="manualUserEmail" required
+            <paper-input label="[[manualEmailAddressLabel]]" type="email" name="email" value="" id="manualUserEmail" required
             pattern="{{resources.regexes.emailValidationPattern}}"
             error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter">
             </paper-input>
@@ -79,10 +80,10 @@
           </form>
           <div class="buttons">
             <paper-button class="anchor-button" dialog-dismiss>
-            <strong>{{resources.dismissText}}</strong>
+            <strong>[[dismissText]]</strong>
             </paper-button>
             <paper-button class="anchor-button" autofocus on-tap="submitPostForm" id="manualAddSubmitButton">
-            <strong>{{resources.saveIndividualUserButton}}</strong>
+            <strong>[[saveIndividualUserButton]]</strong>
             </paper-button>
           </div>
         </div>
@@ -120,6 +121,24 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.groupAddTab = __i18n__['groupAddTab'];
+        this.userAddTab = __i18n__['userAddTab'];
+        this.domainAddTab = __i18n__['domainAddTab'];
+        this.manualAddTab = __i18n__['manualAddTab'];
+        this.saveMultipleUsersButton = __i18n__['saveMultipleUsersButton'];
+        this.groupAddSearchButton = __i18n__['groupAddSearchButton'];
+        this.groupAddEmailAddressLabel = __i18n__['groupAddEmailAddressLabel'];
+        this.groupAddEmailAddressDefinition = __i18n__['groupAddEmailAddressDefinition'];
+        this.saveIndividualUserButton = __i18n__['saveIndividualUserButton'];
+        this.userAddSearchButton = __i18n__['userAddSearchButton'];
+        this.userAddEmailAddressLabel = __i18n__['userAddEmailAddressLabel'];
+        this.userAddEmailAddressDefinition = __i18n__['userAddEmailAddressDefinition'];
+        this.domainAddSearchButton = __i18n__['domainAddSearchButton'];
+        this.manualFullNameLabel = __i18n__['manualFullNameLabel'];
+        this.manualEmailAddressLabel = __i18n__['manualEmailAddressLabel'];
+        this.dismissText = __i18n__['dismissText'];
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.resources.manualAddFormId);

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -4,8 +4,9 @@
 <link rel="import" href="bower_components/paper-dialog/paper-dialog.html" />
 <link rel="import" href="bower_components/paper-input/paper-input.html" />
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
-<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />>
+<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="user-details-dialog">
   <style is="custom-style">
@@ -61,13 +62,13 @@
             <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
             <paper-button on-tap="submitForm" class="topLineButton" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>
           </form>
-          <paper-icon-button icon="close" title="{{resources.closeText}}" id="{{resources.userDetailsButtonId}}" on-tap="closeDialog"></paper-icon-button>
+          <paper-icon-button icon="close" title="[[closeText]]" id="{{resources.userDetailsButtonId}}" on-tap="closeDialog"></paper-icon-button>
         </paper-icon-item>
       </paper-listbox>
       <div id="rowHolder" class="vertical center-justified layout">
-        <strong>{{resources.inviteCodeLabel}}</strong>
+        <strong>[[inviteCodeLabel]]</strong>
         <template is="dom-if" if="[[!inviteCodeJson.invite_code]]">
-          <p>{{resources.inviteCodeNeedServerText}}</p>
+          <p>[[inviteCodeNeedServerText]]</p>
         </template>
         <template is="dom-if" if="[[inviteCodeJson.invite_code]]">
           <paper-input readonly type="text" id="lastInviteCode" value="{{inviteCodeJson.invite_code}}"></paper-input>
@@ -77,13 +78,13 @@
       <div class="buttons">
         <template is="dom-if" if="[[inviteCodeJson.invite_code]]">
           <paper-button on-tap="copyInviteCode" class="anchor-button" id="copyInviteCodeButton" type="submit">
-            <iron-icon icon="content-copy"></iron-icon> <strong>{{resources.copyLabel}}</strong>
+            <iron-icon icon="content-copy"></iron-icon> <strong>[[copyLabel]]</strong>
           </paper-button>
           <form is="iron-form" id="rotateKeysForm" method="post" action="{{resources.rotateKeysUrl}}" on-iron-form-response="parseRotateResponse" on-iron-form-presubmit="setRotateKeysAndEnable">
             <input type="hidden" name="user_id" value="{{item.id}}">
             <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
             <paper-button on-tap="submitForm" class="anchor-button" id="rotateKeysButton" type="submit">
-              <iron-icon icon="refresh"></iron-icon> <strong>{{resources.rotateKeysLabel}}</strong>
+              <iron-icon icon="refresh"></iron-icon> <strong>[[rotateKeysLabel]]</strong>
             </paper-button>
           </form>
         </template>
@@ -92,7 +93,7 @@
           <input type="hidden" name="_xsrf_token" value="{{xsrfToken}}">
           <paper-button on-tap="submitForm" class="delete-button" id="userDeleteButton" type="submit">
             <iron-icon icon="delete"></iron-icon>
-            <strong>{{resources.userDeleteLabel}}</strong>
+            <strong>[[userDeleteLabel]]</strong>
           </paper-button>
         </form>
       </div>
@@ -135,6 +136,14 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.closeText = __i18n__['closeText'];
+        this.inviteCodeLabel = __i18n__['inviteCodeLabel'];
+        this.inviteCodeNeedServerText = __i18n__['inviteCodeNeedServerText'];
+        this.copyLabel = __i18n__['copyLabel'];
+        this.rotateKeysLabel = __i18n__['rotateKeysLabel'];
+        this.userDeleteLabel = __i18n__['userDeleteLabel'];
       },
       setRotateKeysAndEnable: function() {
         this.setRotateKeysJsonPrefix();

--- a/ufo/static/userList.html
+++ b/ufo/static/userList.html
@@ -2,8 +2,9 @@
 <link rel="import" href="bower_components/iron-form/iron-form.html" />
 <link rel="import" href="bower_components/paper-button/paper-button.html" />
 <link rel="import" href="bower_components/paper-item/paper-item.html" />
-<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />>
+<link rel="import" href="bower_components/paper-listbox/paper-listbox.html" />
 <link rel="import" href="bower_components/paper-spinner/paper-spinner.html" />
+<link rel="import" href="bower_components/quaintous-i18n/quaintous-i18n.html"/>
 
 <dom-module id="user-list">
   <style is="custom-style">
@@ -53,9 +54,9 @@
     <paper-listbox>
       <paper-icon-item id="columnHeader" class="horizontal layout">
         <iron-icon src="{{resources.userIconUrl}}" class="noDisplay" item-icon></iron-icon>
-        <div class="first-div"><strong>{{resources.nameColumnHeader}}</strong></div>
-        <div class="second-div flex"><strong>{{resources.emailColumnHeader}}</strong></div>
-        <div class="third-div"><strong>{{resources.accessColumnHeader}}</strong></div>
+        <div class="first-div"><strong>[[nameColumnHeader]]</strong></div>
+        <div class="second-div flex"><strong>[[emailColumnHeader]]</strong></div>
+        <div class="third-div"><strong>[[accessColumnHeader]]</strong></div>
         <paper-icon-button icon="expand-more" class="noDisplay"></paper-icon-button>
       </paper-icon-item>
       <template is="dom-repeat" items="{{_limitResults(ajaxResponse.items, isShowingAll)}}" id="repeatToRerender">
@@ -69,13 +70,13 @@
             <paper-button on-tap="submitRevokeForm" class="topLineButton leftTextAlign" id="userDisableEnableButton" type="submit"><strong>{{item.accessChange}}</strong></paper-button>
           </form>
           <user-details-dialog id="detailsHolder" resources="{{resources}}" item="{{item}}"></user-details-dialog>
-          <paper-icon-button icon="expand-more" title="{{resources.userDetailsExpandText}}" id="{{resources.userDetailsButtonId}}"></paper-icon-button>
+          <paper-icon-button icon="expand-more" title="[[userDetailsExpandText]]" id="{{resources.userDetailsButtonId}}"></paper-icon-button>
         </paper-icon-item>
       </template>
       <template is="dom-if" if="[[_hasMoreToShow(ajaxResponse.items, isShowingAll)]]">
         <paper-item id="showMore" class="horizontal layout start-justified">
           <paper-button class="see-all-button" on-tap="_flipShowingAll">
-          {{resources.userSeeAllText}}
+          [[userSeeAllText]]
           </paper-button>
         </paper-item>
       </template>
@@ -121,6 +122,13 @@
         if (xsrfElement) {
           this.xsrfToken = xsrfElement.value;
         }
+      },
+      attached: function() {
+        this.nameColumnHeader = __i18n__['nameColumnHeader'];
+        this.emailColumnHeader = __i18n__['emailColumnHeader'];
+        this.accessColumnHeader = __i18n__['accessColumnHeader'];
+        this.userDetailsExpandText = __i18n__['userDetailsExpandText'];
+        this.userSeeAllText = __i18n__['userSeeAllText'];
       },
       _limitCharacters: function(text) {
         if (text.length > this.characterLimit) {


### PR DESCRIPTION
A lot of Polymer elements/components are modified in this PR, but as you'll see the changes are pretty small in nature, just copied multiple times over. Each change is basically as follows:
1. Make the dom module reference a new property for the i18n message (rather than referencing resources).
2. Make the binding one way instead of two way (use square brackets [] instead of curly braces {}).
3. Set the new property inside of the attached event handler function for the dom module (have to use attached to ensure that quaintous-i18n is already loaded) using the **i18n** function from quaintous-i18n.
4. Add quaintous-i18n as a relative import. This isn't actually necessary because of how we handle vulcanization, but it is still included to show where the reference comes from.

Finally, I removed all the messages from the resource dictionary since the resource dictionary is no longer being reference for them.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/203)

<!-- Reviewable:end -->
