### PR TITLE
Make Vulcanized HTML not Cached to Avoid i18n Problems

### DIFF
--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -15,6 +15,11 @@ from ufo.handlers import user
 def landing():
   return flask.render_template('landing.html')
 
+# There's an issue in the web driver tests with our vulcanized JS and HTML
+# files getting cached and executing the i18n calls early, such as before the
+# messages.json file is loaded. Making the files not cached fixes this for now.
+# TODO(eholder): Investigate other solutions instead of not caching the
+# vulcanized files.
 @ufo.app.route('/vulcanized_html')
 def vulcanized_html():
   return flask.send_file('static/vulcanized.html', cache_timeout=1)

--- a/ufo/handlers/routes.py
+++ b/ufo/handlers/routes.py
@@ -15,8 +15,12 @@ from ufo.handlers import user
 def landing():
   return flask.render_template('landing.html')
 
-@ufo.app.route('/vulcanized')
-def vulcanized():
+@ufo.app.route('/vulcanized_html')
+def vulcanized_html():
+  return flask.send_file('static/vulcanized.html', cache_timeout=1)
+
+@ufo.app.route('/vulcanized_js')
+def vulcanized_js():
   return flask.send_file('static/vulcanized.js', cache_timeout=1)
 
 

--- a/ufo/templates/base.html
+++ b/ufo/templates/base.html
@@ -5,8 +5,8 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self'; script-src 'self' www.google.com/recaptcha/api.js https://www.gstatic.com/recaptcha/api2/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; frame-src 'self' https://www.google.com/recaptcha/api2/">
   <!-- Include web components script for Polymer to work on firefox. -->
   <script src="{{ url_for('static', filename='bower_components/webcomponentsjs/webcomponents-lite.min.js') }}"></script>
-  <link rel="import" href="{{ url_for('static', filename='vulcanized.html') }}" />
-  <script src="{{ url_for('vulcanized') }}"></script>
+  <link rel="import" href="{{ url_for('vulcanized_html') }}" />
+  <script src="{{ url_for('vulcanized_js') }}"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <link rel="shortcut icon" href="{{ url_for('static', filename='img/favicon.png') }}" type="image/x-icon"/>
   {% block head %}{% endblock %}


### PR DESCRIPTION
There's an issue in the web driver tests with our vulcanized HTML file getting cached and executing the i18n calls early, such as before the messages.json file is loaded. Making the file not cached fixes this for now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/211)

<!-- Reviewable:end -->
