### PR TITLE
Making the close dialog work consistently

### DIFF
--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -242,6 +242,9 @@
         this.showHideEdit(true);
       },
       resetInputs: function() {
+        if (this.oldItem == undefined) {
+          return;
+        }
         var editInputs = this.getElementsByClassName('editInputFields');
         for (var i in editInputs) {
           editInputs[i].value = this.oldItem[editInputs[i].name];


### PR DESCRIPTION
It was failing because the reset value was coming up undefined if the user had never entered edit mode. In that case we don't need to reset anything however, so I just checked for that and returned out which allows the close process to proceed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/224)

<!-- Reviewable:end -->
