### PR TITLE
Fix alignment for button text in the edit server dialog.

### DIFF
--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -44,7 +44,7 @@
       display: none;
     }
     .showElement {
-      display: inline-block;
+      display: inline-flex;
     }
   </style>
   <template>
@@ -102,11 +102,14 @@
       </div>
       <br>
       <div class="buttons">
-        <paper-button class="editElements hideElement anchor-button" on-tap="cancelServerEdit">
-        <strong>[[dismissText]]</strong>
+        <paper-button class="editElements hideElement anchor-button"
+                      on-tap="cancelServerEdit">
+          <strong>[[dismissText]]</strong>
         </paper-button>
-        <paper-button class="editElements hideElement anchor-button" on-tap="submitEditForm" id="serverEditSubmitButton">
-        <strong>[[saveText]]</strong>
+        <paper-button class="editElements hideElement anchor-button"
+                      on-tap="submitEditForm"
+                      id="serverEditSubmitButton">
+          <strong>[[saveText]]</strong>
         </paper-button>
         <form is="iron-form" id="serverDeleteForm" method="post" action="{{resources.proxyServerDeleteUrl}}" on-iron-form-response="parseDeleteResponse" on-iron-form-presubmit="enableSpinner">
           <input type="hidden" name="server_id" value="{{item.id}}">


### PR DESCRIPTION
I couldn't see why inline-block was used here.  But everything looks and works fine with this fix.

Before:
![screenshot from 2016-07-22 09 10 07](https://cloud.githubusercontent.com/assets/6977544/17070259/b845f84e-500f-11e6-81e7-a25383158a89.png)

After
![screenshot from 2016-07-22 13 15 29](https://cloud.githubusercontent.com/assets/6977544/17070262/bfe0c1a6-500f-11e6-9b80-b2bd13ff15ab.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/231)

<!-- Reviewable:end -->
