### PR TITLE
Making public key error more descriptive and moving the errors themselves over to i18n

### DIFF
--- a/ufo/services/regex.py
+++ b/ufo/services/regex.py
@@ -1,21 +1,12 @@
 """Regex module which provides regular expressions to validate client input."""
 
-# TODO(eholder): Move these over to javascript and i18n as appropriate once
-# we've decided how to structure the client side code.
 # Set jinja environment globals
 EMAIL_VALIDATION_PATTERN = r'[^@]+@[^@]+.[^@]+'
-EMAIL_VALIDATION_ERROR = 'Please supply a valid email address.'
 # Key lookup for users and group allows email or unique id.
 KEY_LOOKUP_PATTERN = r'([^@]+@[^@]+.[^@]+|[a-zA-Z0-9]+)'
-KEY_LOOKUP_ERROR = 'Please supply a valid email address or unique id.'
 PUBLIC_KEY_PATTERN = r'ssh-rsa AAAA[0-9A-Za-z+/]+[=]{0,3}'
-PUBLIC_KEY_ERROR = ('Please supply a valid public key in a format such as '
-                    '"ssh-rsa AAAA..."')
 PRIVATE_KEY_PATTERN = (r'-----BEGIN RSA PRIVATE KEY-----[0-9A-Za-z+\/=\r\n ]+'
                        r'-----END RSA PRIVATE KEY-----')
-PRIVATE_KEY_ERROR = ('Please supply a valid private key in a format such as '
-                     '"-----BEGIN RSA PRIVATE KEY----- ... '
-                     '-----END RSA PRIVATE KEY-----"')
 # For information on where this huge regex came from, see here:
 # http://stackoverflow.com/a/17871737/2216222
 IP_V6_REGEX = (r'(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|'
@@ -38,17 +29,10 @@ IP_V6_REGEX = (r'(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|'
 IP_V4_REGEX = (r'((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|'
                r'(2[0-4]|1{0,1}[0-9]){0,1}[0-9])')
 IP_ADDRESS_PATTERN = IP_V6_REGEX + r'|' + IP_V4_REGEX
-IP_ADDRESS_ERROR = ('Please supply a valid ip address in v4 or v6 format '
-                    '(with groups of 0s included).')
 REGEXES_AND_ERRORS_DICTIONARY =  {
     'emailValidationPattern': str(EMAIL_VALIDATION_PATTERN),
-    'emailValidationError': EMAIL_VALIDATION_ERROR,
     'keyLookupPattern': str(KEY_LOOKUP_PATTERN),
-    'keyLookupError': KEY_LOOKUP_ERROR,
     'publicKeyPattern': str(PUBLIC_KEY_PATTERN),
-    'publicKeyError': PUBLIC_KEY_ERROR,
     'privateKeyPattern': str(PRIVATE_KEY_PATTERN),
-    'privateKeyError': PRIVATE_KEY_ERROR,
     'ipAddressPattern': str(IP_ADDRESS_PATTERN),
-    'ipAddressError': IP_ADDRESS_ERROR,
 }

--- a/ufo/services/regex_test.py
+++ b/ufo/services/regex_test.py
@@ -21,15 +21,10 @@ class RegexTest(unittest.TestCase):
     """Test the list user handler gets users from the database."""
     self.assertIn('emailValidationPattern',
                   regex.REGEXES_AND_ERRORS_DICTIONARY)
-    self.assertIn('emailValidationError', regex.REGEXES_AND_ERRORS_DICTIONARY)
     self.assertIn('keyLookupPattern', regex.REGEXES_AND_ERRORS_DICTIONARY)
-    self.assertIn('keyLookupError', regex.REGEXES_AND_ERRORS_DICTIONARY)
     self.assertIn('publicKeyPattern', regex.REGEXES_AND_ERRORS_DICTIONARY)
-    self.assertIn('publicKeyError', regex.REGEXES_AND_ERRORS_DICTIONARY)
     self.assertIn('privateKeyPattern', regex.REGEXES_AND_ERRORS_DICTIONARY)
-    self.assertIn('privateKeyError', regex.REGEXES_AND_ERRORS_DICTIONARY)
     self.assertIn('ipAddressPattern', regex.REGEXES_AND_ERRORS_DICTIONARY)
-    self.assertIn('ipAddressError', regex.REGEXES_AND_ERRORS_DICTIONARY)
 
   def testEmailPatternMatchesValidEmailAddresses(self):
     """Test the email regex pattern matches valid email addresses."""

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -63,7 +63,7 @@
       </template>
       <div id="rowHolder" class="vertical center-justified layout">
         <form is="iron-form" id="serverEditForm" method="post" action="{{resources.proxyServerEditUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parseEditResponse">
-          <paper-input class="editInputFields" disabled label="[[ipLabel]]" type="text" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" value="[[item.ip_address]]" on-keypress="submitIfEnter" id="{{resources.ipInput}}"></paper-input>
+          <paper-input class="editInputFields" disabled label="[[ipLabel]]" type="text" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="[[ipAddressError]]" value="[[item.ip_address]]" on-keypress="submitIfEnter" id="{{resources.ipInput}}"></paper-input>
           <paper-input class="editInputFields" disabled label="[[nameLabel]]" type="text" name="name" required value="[[item.name]]" on-keypress="submitIfEnter" id="{{resources.nameInput}}"></paper-input>
           <!-- TODO add the ability to upload files -->
           <paper-input class="editInputFields"
@@ -73,7 +73,7 @@
                        required
                        max-rows="[[resources.textAreaMaxRows]]"
                        pattern="[[resources.regexes.privateKeyPattern]]"
-                       error-message="[[resources.regexes.privateKeyError]]"
+                       error-message="[[privateKeyError]]"
                        value="[[item.ssh_private_key]]"
                        on-keypress="doNothingOnEnter"
                        on-keydown="doNothingOnEnter"
@@ -88,7 +88,7 @@
                        name="host_public_key"
                        required
                        pattern="{{resources.regexes.publicKeyPattern}}"
-                       error-message="{{resources.regexes.publicKeyError}}"
+                       error-message="[[publicKeyError]]"
                        value="[[item.host_public_key]]"
                        on-keypress="submitIfEnter"
                        id="{{resources.hostPublicKeyInput}}">
@@ -172,6 +172,9 @@
         this.dismissText = I18N.__('dismissText');
         this.saveText = I18N.__('saveText');
         this.proxyServerDeleteLabel = I18N.__('proxyServerDeleteLabel');
+        this.publicKeyError = I18N.__('publicKeyError');
+        this.privateKeyError = I18N.__('privateKeyError');
+        this.ipAddressError = I18N.__('ipAddressError');
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/locales/en/messages.json
+++ b/ufo/static/locales/en/messages.json
@@ -96,5 +96,10 @@
   "saveMultipleUsersButton": "Add Users",
   "saveIndividualUserButton": "Add User",
   "versionText": "Version: ",
-  "versionUpdateText": "A newer version is available on Github: "
+  "versionUpdateText": "A newer version is available on Github: ",
+  "emailValidationError": "Please supply a valid email address.",
+  "keyLookupError": "Please supply a valid email address or unique id.",
+  "publicKeyError": "Please supply a valid public key in a format such as 'ssh-rsa AAAA...' (no email address afterwards).",
+  "privateKeyError": "Please supply a valid private key in a format such as '-----BEGIN RSA PRIVATE KEY----- ... -----END RSA PRIVATE KEY-----'.",
+  "ipAddressError": "Please supply a valid ip address in v4 or v6 format (with groups of 0s included)."
 }

--- a/ufo/static/loginForm.html
+++ b/ufo/static/loginForm.html
@@ -20,7 +20,7 @@
   </style>
   <template>
     <form id="loginForm" method="POST">
-      <paper-input label="[[emailLabel]]" id="email" name="email" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter"></paper-input>
+      <paper-input label="[[emailLabel]]" id="email" name="email" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="[[emailValidationError]]" on-keypress="submitIfEnter"></paper-input>
       <paper-input type="password" label="[[passwordLabel]]" id="password" name="password" required on-keypress="submitIfEnter"></paper-input>
 
       <template is="dom-if" if="{{shouldShowRecaptcha}}">
@@ -70,6 +70,7 @@
         this.emailLabel = I18N.__('emailLabel');
         this.passwordLabel = I18N.__('passwordLabel');
         this.loginText = I18N.__('loginText');
+        this.emailValidationError = I18N.__('emailValidationError');
       },
       submitLoginForm: function() {
         this.querySelector('#loginForm').submit();

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -22,7 +22,7 @@
         <paper-spinner id="serverSpinner" class="absolutePositionSpinner" active$={{loading}}></paper-spinner>
       </template>
       <form is="iron-form" id="serverAddForm" method="post" action="{{resources.proxyServerAddUrl}}" on-iron-form-presubmit="enableSpinner" on-iron-form-response="parsePostResponse">
-        <paper-input label="[[ipLabel]]" type="text" id="{{resources.ipInput}}" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="{{resources.regexes.ipAddressError}}" on-keypress="submitIfEnter"></paper-input>
+        <paper-input label="[[ipLabel]]" type="text" id="{{resources.ipInput}}" name="ip_address" required pattern="{{resources.regexes.ipAddressPattern}}" error-message="[[ipAddressError]]" on-keypress="submitIfEnter"></paper-input>
         <paper-input label="[[nameLabel]]" type="text" id="{{resources.nameInput}}" name="name" required on-keypress="submitIfEnter"></paper-input>
         <!-- TODO add the ability to upload files -->
         <ufo-textarea label="[[sshPrivateKeyLabel]]"
@@ -30,7 +30,7 @@
                       name="ssh_private_key"
                       required max-rows="{{resources.textAreaMaxRows}}"
                       pattern="{{resources.regexes.privateKeyPattern}}"
-                      error-message="{{resources.regexes.privateKeyError}}">
+                      error-message="[[privateKeyError]]">
         </ufo-textarea>
         <br>
         <p>[[sshPrivateKeyText]]</p>
@@ -39,7 +39,7 @@
                      id="{{resources.hostPublicKeyInput}}"
                      name="host_public_key"
                      required pattern="{{resources.regexes.publicKeyPattern}}"
-                     error-message="{{resources.regexes.publicKeyError}}"
+                     error-message="[[publicKeyError]]"
                      on-keypress="submitIfEnter">
         </paper-input>
         <br>
@@ -94,6 +94,9 @@
         this.rsaText = I18N.__('rsaText');
         this.dismissText = I18N.__('dismissText');
         this.confirmText = I18N.__('confirmText');
+        this.publicKeyError = I18N.__('publicKeyError');
+        this.privateKeyError = I18N.__('privateKeyError');
+        this.ipAddressError = I18N.__('ipAddressError');
       },
       enableSpinner: function() {
         this.set('loading', true);

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -87,7 +87,7 @@
           </paper-button>
           <p id="addAdminResponseStatus">{{responseStatus}}</p>
           <form is="iron-form" id="addAdminForm" method="post" action="{{resources.addAdminUrl}}" on-iron-form-response="parseAddAdminResponse" on-iron-form-presubmit="enableSpinner">
-            <paper-input label="[[adminEmailLabel]]" id="paperAdminEmail" name="paperEmail" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter"></paper-input>
+            <paper-input label="[[adminEmailLabel]]" id="paperAdminEmail" name="paperEmail" required pattern="{{resources.regexes.emailValidationPattern}}" error-message="[[emailValidationError]]" on-keypress="submitIfEnter"></paper-input>
             <paper-input label="[[adminPasswordLabel]]" id="paperAdminPassword" name="paperPassword" required on-keypress="submitIfEnter"></paper-input>
             <input type="hidden" name="admin_email" id="jsonEmail" value="" />
             <input type="hidden" name="admin_password" id="jsonPassword" value="" />
@@ -226,6 +226,7 @@
         this.changeAdminPasswordSubmitText = I18N.__('changeAdminPasswordSubmitText');
         this.removeAdminInstructions = I18N.__('removeAdminInstructions');
         this.removeAdminSubmitText = I18N.__('removeAdminSubmitText');
+        this.emailValidationError = I18N.__('emailValidationError');
       },
       openMenu: function() {
         this.set('selectedPage', 0);

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -24,7 +24,7 @@
       <template is="dom-if" if="{{showInputFields}}">
         <form is="iron-form" id="{{formId}}" method="get" action="{{resources.userAddUrl}}" on-iron-form-response="parseGetResponse" on-iron-form-presubmit="enableSpinnerAndSetPrefixes">
           <template is="dom-if" if="[[!idMatches(formId, 'domainAdd')]]">
-            <paper-input label="{{emailLabel}}" type="textbox" name="{{inputName}}" pattern="{{resources.regexes.keyLookupPattern}}" error-message="{{resources.regexes.keyLookupError}}"></paper-input>
+            <paper-input label="{{emailLabel}}" type="textbox" name="{{inputName}}" pattern="{{resources.regexes.keyLookupPattern}}" error-message="[[keyLookupError]]"></paper-input>
             <br>
             <p>{{inputDefinition}}</p>
             <br>
@@ -173,6 +173,7 @@
         this.addFlowNoResults = I18N.__('addFlowNoResults');
         this.lookAgainText = I18N.__('lookAgainText');
         this.dismissText = I18N.__('dismissText');
+        this.keyLookupError = I18N.__('keyLookupError');
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.formId);

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -71,7 +71,7 @@
             </paper-input>
             <paper-input label="[[manualEmailAddressLabel]]" type="email" name="email" value="" id="manualUserEmail" required
             pattern="{{resources.regexes.emailValidationPattern}}"
-            error-message="{{resources.regexes.emailValidationError}}" on-keypress="submitIfEnter">
+            error-message="[[emailValidationError]]" on-keypress="submitIfEnter">
             </paper-input>
             <input type="hidden" name="users" id="manualUserInput" value="">
             <input type="hidden" name="manual" value="true">
@@ -140,6 +140,7 @@
         this.manualFullNameLabel = I18N.__('manualFullNameLabel');
         this.manualEmailAddressLabel = I18N.__('manualEmailAddressLabel');
         this.dismissText = I18N.__('dismissText');
+        this.emailValidationError = I18N.__('emailValidationError');
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.resources.manualAddFormId);


### PR DESCRIPTION
The error texts were accidentally left out in the initial transfer for i18n.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/238)

<!-- Reviewable:end -->
