### PR TITLE
Wrapping proxy server add errors in a new json message

### DIFF
--- a/ufo/__init__.py
+++ b/ufo/__init__.py
@@ -1,3 +1,5 @@
+import json
+
 import flask
 from flask import request
 from flask.ext import sqlalchemy
@@ -96,6 +98,25 @@ def setup_required(func):
       raise SetupNeeded
     return func(*args, **kwargs)
   return decorated_function
+
+def get_json_message(message_key):
+  """Get an i18n-ed message from the appropriate json file for the given key.
+
+  Args:
+    message_key: The message to get.
+
+  Returns:
+    A string the for the i18n-ed message or the key itself if an error occurs.
+  """
+  file_path = (os.getcwd() + '/ufo/static/locales/' +
+               flask.session['language_prefix'] + '/messages.json')
+  try:
+    with open(file_path) as json_file:
+      messages = json.load(json_file)
+      return messages[message_key]
+  except:
+    return message_key
+
 
 from ufo.services import key_distributor
 from ufo.handlers import routes

--- a/ufo/handlers/proxy_server.py
+++ b/ufo/handlers/proxy_server.py
@@ -42,8 +42,14 @@ def proxyserver_add():
   if ssh_private_key_contents is None:
     flask.abort(400)
 
-  server.read_public_key_from_file_contents(host_public_key_contents)
-  server.read_private_key_from_file_contents(ssh_private_key_contents)
+  try:
+    server.read_public_key_from_file_contents(host_public_key_contents)
+  except:
+    flask.abort(400, ufo.get_json_message('publicKeyReadError'))
+  try:
+    server.read_private_key_from_file_contents(ssh_private_key_contents)
+  except:
+    flask.abort(400, ufo.get_json_message('privateKeyReadError'))
 
   try:
     server.save()

--- a/ufo/static/locales/en/messages.json
+++ b/ufo/static/locales/en/messages.json
@@ -96,5 +96,7 @@
   "saveMultipleUsersButton": "Add Users",
   "saveIndividualUserButton": "Add User",
   "versionText": "Version: ",
-  "versionUpdateText": "A newer version is available on Github: "
+  "versionUpdateText": "A newer version is available on Github: ",
+  "publicKeyReadError": "Error reading the public key. Proxy server add aborted.",
+  "privateKeyReadError": "Error reading the private key. Proxy server add aborted."
 }


### PR DESCRIPTION
This also involved creating a JSON message getter for server side errors to be i18n-ed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/239)

<!-- Reviewable:end -->
