### PR TITLE
Fixing issues with the functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "2.7"
 # commands to setup environment and install dependencies
+before_install:
+ - nvm install node
 install:
  - pip install -r requirements.txt
  - python setup_database.py

--- a/tests/ui/admin_flow_test.py
+++ b/tests/ui/admin_flow_test.py
@@ -137,10 +137,9 @@ class AdminFlowTest(BaseTest):
     admin_flow = AdminFlow(self.driver)
     dropdown_menu = admin_flow.getDropdownMenu()
     add_admin_dialog = admin_flow.get_add_admin_dialog(dropdown_menu)
-    with self.assertRaises(NoSuchElementException):
-      response_status = add_admin_dialog.find_element(
-          *AdminFlow.ADD_ADMIN_RESPONSE_STATUS)
-      self.assertIsNone(response_status)
+    response_status = add_admin_dialog.find_element(
+        *AdminFlow.ADD_ADMIN_RESPONSE_STATUS)
+    self.assertEquals('', response_status.text)
 
     # Add the new admin.
     admin_flow.add_test_admin(self.TEST_ADMIN_AS_DICT['email'],
@@ -150,7 +149,7 @@ class AdminFlowTest(BaseTest):
     # Assert that it worked.
     response_status = add_admin_dialog.find_element(
         *AdminFlow.ADD_ADMIN_RESPONSE_STATUS)
-    self.assertIsNotNone(response_status)
+    self.assertNotEqual('', response_status.text)
 
     # Logout of the existing admin account.
     LoginPage(self.driver).Logout(self.args.server_url)

--- a/tests/ui/landing_page.py
+++ b/tests/ui/landing_page.py
@@ -249,3 +249,15 @@ class LandingPage(UfOPageLayout):
     landing_url = server_url + flask.url_for('landing')
     if landing_url != self.driver.current_url:
       self.driver.get(landing_url)
+
+  def tryToCloseDetailsDialogAndRefreshIfFail(self, server_url):
+    """Try to click the close button on a details dialog and refresh on except.
+
+    Args:
+      server_url: The base url portion of the landing page.
+    """
+    user_details_button = self.get_element(LandingPage.USER_DETAILS_BUTTON)
+    try:
+      user_details_button.click()
+    except:
+      self.driver.get(server_url + flask.url_for('landing'))

--- a/tests/ui/landing_page_test.py
+++ b/tests/ui/landing_page_test.py
@@ -24,12 +24,6 @@ class LandingPageTest(BaseTest):
   def tearDown(self):
     """Teardown for test methods."""
     landing_page = LandingPage(self.driver)
-    try:
-      user_details_button = landing_page.get_element(
-          LandingPage.USER_DETAILS_BUTTON)
-      user_details_button.click()
-    except:
-      self.driver.get(self.args.server_url + flask.url_for('landing'))
     landing_page.remove_test_user(BaseTest.TEST_USER_AS_DICT['name'],
                                   self.args.server_url,
                                   should_raise_exception=False)
@@ -107,6 +101,8 @@ class LandingPageTest(BaseTest):
 
     self.assertUserCanBeDisabledAndThenEnabled(False, True)
 
+    landing_page.tryToCloseDetailsDialogAndRefreshIfFail(self.args.server_url)
+
   def testCreateNewInviteCode(self):
     """Test that creating a new invite code actually generates a new one."""
     landing_page = LandingPage(self.driver)
@@ -149,6 +145,8 @@ class LandingPageTest(BaseTest):
     final_invite_code = details_dialog.find_element(
         *LandingPage.USER_INVITE_CODE_TEXT).get_attribute('value')
     self.assertNotEquals(initial_invite_code, final_invite_code)
+
+    landing_page.tryToCloseDetailsDialogAndRefreshIfFail(self.args.server_url)
 
   def testAddServerFromLandingPage(self):
     """Test that adding a server shows up on the server listing."""

--- a/tests/ui/landing_page_test.py
+++ b/tests/ui/landing_page_test.py
@@ -24,6 +24,12 @@ class LandingPageTest(BaseTest):
   def tearDown(self):
     """Teardown for test methods."""
     landing_page = LandingPage(self.driver)
+    try:
+      user_details_button = landing_page.get_element(
+          LandingPage.USER_DETAILS_BUTTON)
+      user_details_button.click()
+    except:
+      self.driver.get(self.args.server_url + flask.url_for('landing'))
     landing_page.remove_test_user(BaseTest.TEST_USER_AS_DICT['name'],
                                   self.args.server_url,
                                   should_raise_exception=False)

--- a/tests/ui/layout.py
+++ b/tests/ui/layout.py
@@ -80,6 +80,7 @@ class UfOPageLayout(BaseDriver):
   USER_COPY_INVITE_BUTTON = (By.ID, 'copyInviteCodeButton')
   USER_ROTATE_KEYS_BUTTON = (By.ID, 'rotateKeysButton')
   USER_DETAILS_SPINNER = (By.ID, 'userDetailsSpinner')
+  USER_DETAILS_BUTTON = (By.ID, 'userDetailsButton')
 
   ADD_SERVER_BUTTON = (By.ID, 'addServerButton')
   SERVER_LIST_ITEM = (By.ID, 'proxyList')


### PR DESCRIPTION
These all passed when run locally so hoping to let the next nightly build give it a try.

The changes to the admin flow test have to do with a change we missed with how the add admin response gets shown. It is always shown, but empty when there is no response rather than not being found. The changes to the landing page test are for the tests which leave a details dialog open. Web driver seems to have trouble clicking the close button on the details dialog occasionally. By attempting that and then just reloading the page if it fails, that allows us to proceed during the tearDown phase which was when the errors actually happened.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/250)

<!-- Reviewable:end -->
