### PR TITLE
Making i18n retry after 1 second if it fails initially.

### DIFF
--- a/ufo/static/addItemButton.html
+++ b/ufo/static/addItemButton.html
@@ -48,6 +48,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.addText == 'userAddText' || this.addText == 'proxyServerAddText') {

--- a/ufo/static/addItemButton.html
+++ b/ufo/static/addItemButton.html
@@ -48,6 +48,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.addText == 'userAddText' || this.addText == 'proxyServerAddText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         switch (this.addType) {
           case 'proxyServer':
             this.addText = I18N.__('proxyServerAddText');

--- a/ufo/static/addModal.html
+++ b/ufo/static/addModal.html
@@ -55,6 +55,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.addText == 'userAddText' || this.addText == 'proxyServerAddText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         switch (this.addType) {
           case 'proxyServer':
             this.addText = I18N.__('proxyServerAddText');

--- a/ufo/static/addModal.html
+++ b/ufo/static/addModal.html
@@ -55,6 +55,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.addText == 'userAddText' || this.addText == 'proxyServerAddText') {

--- a/ufo/static/chromePolicy.html
+++ b/ufo/static/chromePolicy.html
@@ -67,6 +67,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.downloadText == 'downloadText') {

--- a/ufo/static/chromePolicy.html
+++ b/ufo/static/chromePolicy.html
@@ -67,6 +67,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.downloadText == 'downloadText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.policyExplanationText = I18N.__('policyExplanationText');
         this.policyEditText = I18N.__('policyEditText');
         this.adminConsoleText = I18N.__('adminConsoleText');

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -160,6 +160,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.ipAddressError == 'ipAddressError') {

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -160,6 +160,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.ipAddressError == 'ipAddressError') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.editText = I18N.__('editText');
         this.closeText = I18N.__('closeText');
         this.ipLabel = I18N.__('ipLabel');

--- a/ufo/static/errorNotification.html
+++ b/ufo/static/errorNotification.html
@@ -102,6 +102,8 @@
         'ApplicationError': 'showErrorNotification',
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.closeText == 'closeText') {

--- a/ufo/static/errorNotification.html
+++ b/ufo/static/errorNotification.html
@@ -102,6 +102,14 @@
         'ApplicationError': 'showErrorNotification',
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.closeText == 'closeText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.errorTitleText = I18N.__('errorTitleText');
         this.closeText = I18N.__('closeText');
       },

--- a/ufo/static/headerContainer.html
+++ b/ufo/static/headerContainer.html
@@ -49,6 +49,14 @@
       },
       behaviors: [I18N],
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.titleText == 'chromePolicyTitleText' || this.titleText == 'loginTitleText' || this.titleText == 'oauthTitleText' || this.titleText == 'proxyServerTitleText' || this.titleText == 'settingsTitleText' || this.titleText == 'userTitleText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         switch (this.headerType) {
           case 'chromePolicy':
             this.titleText = I18N.__('chromePolicyTitleText');

--- a/ufo/static/headerContainer.html
+++ b/ufo/static/headerContainer.html
@@ -49,6 +49,8 @@
       },
       behaviors: [I18N],
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.titleText == 'chromePolicyTitleText' || this.titleText == 'loginTitleText' || this.titleText == 'oauthTitleText' || this.titleText == 'proxyServerTitleText' || this.titleText == 'settingsTitleText' || this.titleText == 'userTitleText') {

--- a/ufo/static/leftIconContainer.html
+++ b/ufo/static/leftIconContainer.html
@@ -72,6 +72,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.addText == 'userAddText' || this.addText == 'proxyServerAddText') {

--- a/ufo/static/leftIconContainer.html
+++ b/ufo/static/leftIconContainer.html
@@ -72,6 +72,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.addText == 'userAddText' || this.addText == 'proxyServerAddText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         switch (this.addType) {
           case 'proxyServer':
             this.addText = I18N.__('proxyServerAddText');

--- a/ufo/static/loginForm.html
+++ b/ufo/static/loginForm.html
@@ -74,6 +74,15 @@
           this.querySelector('#recaptchaDiv')
             .setAttribute('data-sitekey', this.resources.recaptchaKey);
         }
+
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.tooManyFailuresText == 'tooManyFailuresText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.emailLabel = I18N.__('emailLabel');
         this.passwordLabel = I18N.__('passwordLabel');
         this.loginText = I18N.__('loginText');

--- a/ufo/static/loginForm.html
+++ b/ufo/static/loginForm.html
@@ -75,6 +75,8 @@
             .setAttribute('data-sitekey', this.resources.recaptchaKey);
         }
 
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.tooManyFailuresText == 'tooManyFailuresText') {

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -114,6 +114,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.adminPasswordLabel == 'adminPasswordLabel') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.welcomeText = I18N.__('welcomeText');
         this.googleDomainPromptText = I18N.__('googleDomainPromptText');
         this.successSetupText = I18N.__('successSetupText');

--- a/ufo/static/oauthConfiguration.html
+++ b/ufo/static/oauthConfiguration.html
@@ -114,6 +114,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.adminPasswordLabel == 'adminPasswordLabel') {

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -85,6 +85,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.ipAddressError == 'ipAddressError') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.ipLabel = I18N.__('ipLabel');
         this.nameLabel = I18N.__('nameLabel');
         this.sshPrivateKeyLabel = I18N.__('sshPrivateKeyLabel');

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -85,6 +85,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.ipAddressError == 'ipAddressError') {

--- a/ufo/static/serverList.html
+++ b/ufo/static/serverList.html
@@ -120,6 +120,8 @@
       },
       behaviors: [I18N],
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.proxyServerSeeAllText == 'proxyServerSeeAllText') {

--- a/ufo/static/serverList.html
+++ b/ufo/static/serverList.html
@@ -120,6 +120,14 @@
       },
       behaviors: [I18N],
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.proxyServerSeeAllText == 'proxyServerSeeAllText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.nameColumnHeader = I18N.__('nameColumnHeader');
         this.ipColumnHeader = I18N.__('ipColumnHeader');
         this.modifyColumnHeader = I18N.__('modifyColumnHeader');

--- a/ufo/static/settingsConfiguration.html
+++ b/ufo/static/settingsConfiguration.html
@@ -67,6 +67,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.saveText == 'saveText') {

--- a/ufo/static/settingsConfiguration.html
+++ b/ufo/static/settingsConfiguration.html
@@ -67,6 +67,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.saveText == 'saveText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.proxyValidityText = I18N.__('proxyValidityText');
         this.networkJailText = I18N.__('networkJailText');
         this.saveText = I18N.__('saveText');

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -213,6 +213,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.emailValidationError == 'emailValidationError') {

--- a/ufo/static/ufoDropdownMenu.html
+++ b/ufo/static/ufoDropdownMenu.html
@@ -213,6 +213,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.emailValidationError == 'emailValidationError') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.addAdminText = I18N.__('addAdminText');
         this.changeAdminPasswordText = I18N.__('changeAdminPasswordText');
         this.removeAdminText = I18N.__('removeAdminText');

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -170,6 +170,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.keyLookupError == 'keyLookupError') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.addFlowNoResults = I18N.__('addFlowNoResults');
         this.lookAgainText = I18N.__('lookAgainText');
         this.dismissText = I18N.__('dismissText');

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -170,6 +170,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.keyLookupError == 'keyLookupError') {

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -124,6 +124,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.emailValidationError == 'emailValidationError') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.groupAddTab = I18N.__('groupAddTab');
         this.userAddTab = I18N.__('userAddTab');
         this.domainAddTab = I18N.__('domainAddTab');

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -124,6 +124,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.emailValidationError == 'emailValidationError') {

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -139,6 +139,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.userDeleteLabel == 'userDeleteLabel') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.closeText = I18N.__('closeText');
         this.inviteCodeLabel = I18N.__('inviteCodeLabel');
         this.inviteCodeNeedServerText = I18N.__('inviteCodeNeedServerText');

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -139,6 +139,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.userDeleteLabel == 'userDeleteLabel') {

--- a/ufo/static/userList.html
+++ b/ufo/static/userList.html
@@ -131,6 +131,8 @@
         }
       },
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.userSeeAllText == 'userSeeAllText') {

--- a/ufo/static/userList.html
+++ b/ufo/static/userList.html
@@ -131,6 +131,14 @@
         }
       },
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.userSeeAllText == 'userSeeAllText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.nameColumnHeader = I18N.__('nameColumnHeader');
         this.emailColumnHeader = I18N.__('emailColumnHeader');
         this.accessColumnHeader = I18N.__('accessColumnHeader');

--- a/ufo/static/versionDisplay.html
+++ b/ufo/static/versionDisplay.html
@@ -58,6 +58,8 @@
       },
       behaviors: [I18N],
       attached: function() {
+        // Notes about this retry can be found on the dev guide under Assorted
+        // Notes and Retry for i18n After 1 Second.
         this.setI18nText();
         setTimeout(function() {
           if (this.versionUpdateText == 'versionUpdateText') {

--- a/ufo/static/versionDisplay.html
+++ b/ufo/static/versionDisplay.html
@@ -58,6 +58,14 @@
       },
       behaviors: [I18N],
       attached: function() {
+        this.setI18nText();
+        setTimeout(function() {
+          if (this.versionUpdateText == 'versionUpdateText') {
+            this.setI18nText();
+          }
+        }, 1000);
+      },
+      setI18nText: function() {
         this.versionText = I18N.__('versionText');
         this.versionUpdateText = I18N.__('versionUpdateText');
       },


### PR DESCRIPTION
This change is really pretty straightforward in spite of its size. Basically, all the i18n text variable setting is moved out to its own function for each element. In the attached listener, that function is called, just as normal.

The trick is that after the initial call, a timeout is set for 1 second. After 1 second, the extra code will execute which just checks if the last i18n text to be set actually received an i18n-ed value (if it's value is not just its key). If it did not, then retry setting the i18n text for everything in that element. There is no subsequent retry, so if it fails twice, then it just fails until the whole page reloads (this likely means the key isn't defined or doesn't have a translation for the given language). This at least lets us attempt to recover in the event of timing issues with loading different components. This isn't ideal of course, but it's something.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/252)

<!-- Reviewable:end -->
