### PR TITLE
Swap between add elements based on how many are present

### DIFF
--- a/ufo/services/resource_provider.py
+++ b/ufo/services/resource_provider.py
@@ -89,6 +89,10 @@ def _get_resources():
     'regexes': regex.REGEXES_AND_ERRORS_DICTIONARY,
     'jsonPrefix': ufo.XSSI_PREFIX,
     'maxFailedLoginsBeforeRecaptcha': ufo.MAX_FAILED_LOGINS_BEFORE_RECAPTCHA,
+    'userAddListFlipperId': 'userAddListFlipper',
+    'proxyServerAddListFlipperId': 'proxyServerAddListFlipper',
+    'userAddTabsId': 'userAddTabs',
+    'proxyServerAddFormId': 'serverAddFormHolder',
   }
 
 def set_jinja_globals():

--- a/ufo/static/addListFlipper.html
+++ b/ufo/static/addListFlipper.html
@@ -1,0 +1,53 @@
+<link rel="import" href="bower_components/iron-pages/iron-pages.html" />
+
+<dom-module id="add-list-flipper">
+  <template>
+    <iron-pages selected="{{selectedPage}}">
+      <content></content>
+    </iron-pages>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'add-list-flipper',
+      properties: {
+        resources: {
+          type: Object,
+          notify: true,
+        },
+        addType: {
+          type: String,
+          notify: true,
+          value: '',
+        },
+        selectedPage: {
+          type: Number,
+          value: 0,
+        },
+      },
+      setSelectedPageFromResponse: function(response) {
+        if (response.items.length > 0) {
+          this.set('selectedPage', 0);
+        } else {
+          switch (this.addType) {
+            case 'proxyServer':
+              var elementId = this.resources.proxyServerAddFormId;
+              var formHolder = document.getElementById(elementId);
+              if (formHolder) {
+                formHolder.resetForm();
+              }
+              break;
+            default:
+              var elementId = this.resources.userAddTabsId;
+              var tabs = document.getElementById(elementId);
+              if (tabs) {
+                tabs.reopenFromFlipper();
+              }
+              break;
+          }
+          this.set('selectedPage', 1);
+        }
+      },
+    });
+  </script>
+</dom-module>

--- a/ufo/static/editServerDialog.html
+++ b/ufo/static/editServerDialog.html
@@ -235,6 +235,11 @@
         if (listElem) {
           listElem.setAjaxResponse(updatedJson);
         }
+        var flipperId = this.resources.proxyServerAddListFlipperId;
+        var flipperElem = document.getElementById(flipperId);
+        if (flipperElem) {
+          flipperElem.setSelectedPageFromResponse(updatedJson);
+        }
       },
       openDialog: function() {
         var dialog = this.querySelector('#' + this.resources.proxyServerDetailsOverlayId);

--- a/ufo/static/locales/en/messages.json
+++ b/ufo/static/locales/en/messages.json
@@ -24,7 +24,7 @@
   "passwordLabel": "Password",
   "loginText": "Login",
   "adminTitleText": "First Admin Configuration",
-  "oauthTitleText": "Oauth Configuration",
+  "oauthTitleText": "OAuth Configuration",
   "welcomeText": "Welcome to the uProxy for Organizations Management Server!",
   "firstSteps": "Please complete initial setup by adding the first admin account. Afterwards, you will be prompted to login to that account. You may optionally configure a Google Apps domain afterwards and then begin adding users and servers.",
   "googleDomainPromptText": "If you are planning on integrating with a Google Apps domain, you'll need to authorize this application. The Management Server uses this authorization to keep the list of users in your domain in sync with the access control lists on uProxy servers. The credentials you authorize will be shared by any administrators who are able to log into this server. If you do not plan on using a Google Apps domain with this product, you can just create an admin account and proceed to adding users and servers.",
@@ -115,5 +115,6 @@
   "noAdministratorError": "Please enter an administrator email and password.",
   "noOauthCodeError": "No OAuth code was found in the request.",
   "domainInvalidError": "Credentials do not match given domain.",
-  "nonAdminAccessError": "Credentials do not have admin access."
+  "nonAdminAccessError": "Credentials do not have admin access.",
+  "oauthFeature": "Please note that this feature only works if you have OAuth configured with a Google Apps domain. You can do so in the OAuth Configuration section or simply add users manually."
 }

--- a/ufo/static/paperDisplayTemplate.html
+++ b/ufo/static/paperDisplayTemplate.html
@@ -1,6 +1,4 @@
-<link rel="import" href="bower_components/iron-ajax/iron-ajax.html" />
 <link rel="import" href="bower_components/paper-material/paper-material.html" />
-<link rel="import" href="bower_components/paper-toolbar/paper-toolbar.html" />
 
 <dom-module id="paper-display-template">
   <template>

--- a/ufo/static/serverAddForm.html
+++ b/ufo/static/serverAddForm.html
@@ -145,9 +145,21 @@
         if (listElem) {
           listElem.setAjaxResponse(updatedServersJson);
         }
+        var flipperId = this.resources.proxyServerAddListFlipperId;
+        var flipperElem = document.getElementById(flipperId);
+        if (flipperElem) {
+          flipperElem.setSelectedPageFromResponse(updatedServersJson);
+        }
       },
       resetForm: function(e, details) {
-        document.getElementById('serverAddForm').reset();
+        var formElem = this.querySelector('#serverAddForm');
+        if (formElem) {
+          formElem.querySelector('#' + this.resources.ipInput).value = "";
+          formElem.querySelector('#' + this.resources.nameInput).value = "";
+          formElem.querySelector('#' + this.resources.sshPrivateKeyInput).value = "";
+          formElem.querySelector('#' + this.resources.hostPublicKeyInput).value = "";
+          formElem.reset();
+        }
       },
       submitIfEnter: function(e) {
         if (e.keyCode === 13) {

--- a/ufo/static/serverList.html
+++ b/ufo/static/serverList.html
@@ -50,6 +50,7 @@
       id="getItemsAjax"
       loading="{{loading}}"
       last-response="{{ajaxResponse}}"
+      on-response="parseListResponse"
       json-prefix="{{resources.jsonPrefix}}">
     </iron-ajax>
     <paper-listbox>
@@ -209,6 +210,14 @@
         if (elem) {
           var dialogHolder = elem.querySelector('#detailsHolder');
           dialogHolder.openServerEdit();
+        }
+      },
+      parseListResponse: function() {
+        var updatedServerResponse = this.ajaxResponse;
+        var flipperId = this.resources.proxyServerAddListFlipperId;
+        var flipperElem = document.getElementById(flipperId);
+        if (flipperElem) {
+          flipperElem.setSelectedPageFromResponse(updatedServerResponse);
         }
       },
     });

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -198,6 +198,8 @@
         this.enableSpinner();
       },
       submitGetForm: function() {
+        this.querySelector('#' + this.formId).request.handleAs = "json";
+        this.querySelector('#' + this.formId).request.jsonPrefix = this.resources.jsonPrefix;
         this.querySelector('#' + this.formId).submit();
       },
       submitPostForm: function() {
@@ -250,6 +252,11 @@
         var listElem = document.getElementById(this.resources.userListId);
         if (listElem) {
           listElem.setAjaxResponse(updatedUsersJson);
+        }
+        var flipperId = this.resources.userAddListFlipperId;
+        var flipperElem = document.getElementById(flipperId);
+        if (flipperElem) {
+          flipperElem.setSelectedPageFromResponse(updatedUsersJson);
         }
       },
       idMatches: function(id, string1) {

--- a/ufo/static/userAddForm.html
+++ b/ufo/static/userAddForm.html
@@ -27,6 +27,7 @@
             <paper-input label="{{emailLabel}}" type="textbox" name="{{inputName}}" pattern="{{resources.regexes.keyLookupPattern}}" error-message="[[keyLookupError]]"></paper-input>
             <br>
             <p>{{inputDefinition}}</p>
+            <p>[[oauthFeature]]</p>
             <br>
           </template>
           <template is="dom-if" if="[[idMatches(formId, 'domainAdd')]]">
@@ -184,6 +185,7 @@
         this.lookAgainText = I18N.__('lookAgainText');
         this.dismissText = I18N.__('dismissText');
         this.keyLookupError = I18N.__('keyLookupError');
+        this.oauthFeature = I18N.__('oauthFeature');
       },
       setJsonPrefixes: function() {
         var addForm = document.getElementById(this.formId);

--- a/ufo/static/userAddTabs.html
+++ b/ufo/static/userAddTabs.html
@@ -175,17 +175,25 @@
         this.querySelector('#manualAdd').submit();
       },
       closeModal: function() {
+        this.resetAllForms();
+        this.set('loading', false);
+        var userModal = document.getElementById('userModal');
+        if (userModal) {
+          userModal.close();
+        }
+      },
+      resetAllForms: function() {
         this.resetForm();
         var subForms = this.querySelectorAll('user-add-form');
         var i;
         for (i = 0; i < subForms.length; i++) {
           subForms[i].resetForms();
         }
+      },
+      reopenFromFlipper: function() {
+        this.resetAllForms();
         this.set('loading', false);
-        var userModal = document.getElementById('userModal');
-        if (userModal) {
-          userModal.close();
-        }
+        this.set('selected', 0);
       },
       parsePostResponse: function(e, detail) {
         this.sendUsersJsonToList(e.target.request.lastResponse);
@@ -215,6 +223,11 @@
         var listElem = document.getElementById(this.resources.userListId);
         if (listElem) {
           listElem.setAjaxResponse(updatedUsersJson);
+        }
+        var flipperId = this.resources.userAddListFlipperId;
+        var flipperElem = document.getElementById(flipperId);
+        if (flipperElem) {
+          flipperElem.setSelectedPageFromResponse(updatedUsersJson);
         }
       },
       submitIfEnter: function(e) {

--- a/ufo/static/userDetailsDialog.html
+++ b/ufo/static/userDetailsDialog.html
@@ -203,6 +203,11 @@
         if (listElem) {
           listElem.setAjaxResponse(updatedUsersJson);
         }
+        var flipperId = this.resources.userAddListFlipperId;
+        var flipperElem = document.getElementById(flipperId);
+        if (flipperElem) {
+          flipperElem.setSelectedPageFromResponse(updatedUsersJson);
+        }
         this.set('loading', false);
       },
       openDialog: function() {

--- a/ufo/static/userList.html
+++ b/ufo/static/userList.html
@@ -50,6 +50,7 @@
       id="getItemsAjax"
       loading="{{loading}}"
       last-response="{{ajaxResponse}}"
+      on-response="parseListResponse"
       json-prefix="{{resources.jsonPrefix}}">
     </iron-ajax>
     <paper-listbox>
@@ -219,6 +220,14 @@
         if (elem) {
           var dialogHolder = elem.querySelector('#detailsHolder');
           dialogHolder.openServerEdit();
+        }
+      },
+      parseListResponse: function() {
+        var updatedUserResponse = this.ajaxResponse;
+        var flipperId = this.resources.userAddListFlipperId;
+        var flipperElem = document.getElementById(flipperId);
+        if (flipperElem) {
+          flipperElem.setSelectedPageFromResponse(updatedUserResponse);
         }
       },
     });

--- a/ufo/templates/landing.html
+++ b/ufo/templates/landing.html
@@ -2,17 +2,29 @@
 {% block title %}Landing{% endblock %}
 {% block body %}
   <paper-display-template id="userDisplayTemplate">
-    <header-container resources="{{resources}}" has-add-flow="true" header-type="user">
-      <user-list resources="{{resources}}" id="userList" auto-get=true>
-      </user-list>
-    </header-container>
+    <add-list-flipper resources="{{resources}}" id="userAddListFlipper" add-type="user">
+      <header-container resources="{{resources}}" has-add-flow="true" header-type="user">
+        <user-list resources="{{resources}}" id="userList" auto-get=true>
+        </user-list>
+      </header-container>
+      <left-icon-container resources="{{resources}}" add-type="user">
+        <user-add-tabs resources="{{resources}}" id="userAddTabs">
+        </user-add-tabs>
+      </left-icon-container>
+    </add-list-flipper>
   </paper-display-template>
 
   <paper-display-template id="proxyServerDisplayTemplate">
-    <header-container resources="{{resources}}" has-add-flow="true" header-type="proxyServer">
-      <server-list resources="{{resources}}" id="proxyList" auto-get=true>
-      </server-list>
-    </header-container>
+    <add-list-flipper resources="{{resources}}" id="proxyServerAddListFlipper" add-type="proxyServer">
+      <header-container resources="{{resources}}" has-add-flow="true" header-type="proxyServer">
+        <server-list resources="{{resources}}" id="proxyList" auto-get=true>
+        </server-list>
+      </header-container>
+      <left-icon-container resources="{{resources}}" add-type="proxyServer">
+        <server-add-form resources="{{resources}}" id="serverAddFormHolder">
+        </server-add-form>
+      </left-icon-container>
+    </add-list-flipper>
   </paper-display-template>
 
   <paper-display-template id="oauthDisplayTemplate">

--- a/ufo/templates/setup.html
+++ b/ufo/templates/setup.html
@@ -10,40 +10,42 @@
     </paper-display-template>
   {% endif %}
 
-  <paper-display-template id="oauthDisplayTemplate">
-    <header-container resources="{{resources}}" header-type="oauth">
-      <oauth-configuration resources="{{resources}}" configuration="{{configuration_resources}}">
-      </oauth-configuration>
-    </header-container>
-  </paper-display-template>
+  {% if session['isConfigured'] %}
+    <paper-display-template id="oauthDisplayTemplate">
+      <header-container resources="{{resources}}" header-type="oauth">
+        <oauth-configuration resources="{{resources}}" configuration="{{configuration_resources}}">
+        </oauth-configuration>
+      </header-container>
+    </paper-display-template>
 
-  <paper-display-template id="userDisplayTemplate">
-    <left-icon-container resources="{{resources}}" add-type="user">
-      <user-add-tabs resources="{{resources}}">
-      </user-add-tabs>
-    </left-icon-container>
-  </paper-display-template>
+    <paper-display-template id="userDisplayTemplate">
+      <left-icon-container resources="{{resources}}" add-type="user">
+        <user-add-tabs resources="{{resources}}">
+        </user-add-tabs>
+      </left-icon-container>
+    </paper-display-template>
 
-  <paper-display-template id="proxyServerDisplayTemplate">
-    <left-icon-container resources="{{resources}}" add-type="proxyServer">
-      <server-add-form resources="{{resources}}">
-      </server-add-form>
-    </left-icon-container>
-  </paper-display-template>
+    <paper-display-template id="proxyServerDisplayTemplate">
+      <left-icon-container resources="{{resources}}" add-type="proxyServer">
+        <server-add-form resources="{{resources}}">
+        </server-add-form>
+      </left-icon-container>
+    </paper-display-template>
 
-  {% if session['domain'] %}
-    <paper-display-template id="chromePolicyDisplayTemplate">
-      <header-container resources="{{resources}}" header-type="chromePolicy">
-        <chrome-policy resources="{{resources}}">
-        </chrome-policy>
+    {% if session['domain'] %}
+      <paper-display-template id="chromePolicyDisplayTemplate">
+        <header-container resources="{{resources}}" header-type="chromePolicy">
+          <chrome-policy resources="{{resources}}">
+          </chrome-policy>
+        </header-container>
+      </paper-display-template>
+    {% endif %}
+
+    <paper-display-template id="settingsDisplayTemplate">
+      <header-container resources="{{resources}}" header-type="settings">
+        <settings-configuration resources="{{resources}}">
+        </settings-configuration>
       </header-container>
     </paper-display-template>
   {% endif %}
-
-  <paper-display-template id="settingsDisplayTemplate">
-    <header-container resources="{{resources}}" header-type="settings">
-      <settings-configuration resources="{{resources}}">
-      </settings-configuration>
-    </header-container>
-  </paper-display-template>
 {% endblock %}


### PR DESCRIPTION
This change creates an intermediate element (addListFlipper) which is given the last ajax result of users/servers. Based on the amount of users/servers, it will set an iron page to show either the initial add user/server flow (copied from the setup page) if there are currently 0 users/servers and the landing page's listing if there are more than 0 users/servers. This enables the flow we would like for onboarding so that the initial admin is prompted to add users/servers as expected from the landing page.

The setup page will now only show the initial admin configuration with everything else hidden until it is configured.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/265)

<!-- Reviewable:end -->
