### PR TITLE
Update Deployment Guide to Create Backup Deploy Button

### DIFF
--- a/DeploymentGuide.md
+++ b/DeploymentGuide.md
@@ -14,7 +14,7 @@ The click to deploy method creates a new app based on a template from github. He
 
 1. Create Your Instance
 
-  1. [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/uProxy/ufo-management-server-flask/tree/master)
+  1. [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https://github.com/uProxy/ufo-management-server-flask/tree/master) [Backup Deployment Link if Button Isn't Working]((https://dashboard.heroku.com/new?template=https://github.com/uProxy/ufo-management-server-flask/tree/master)
     * It is easier to open this in a new window/tab so you can view the instructions and Heroku at the same time.
     * TODO(eholder): Switch this to production version after beta testing. We want testers to use master in the meantime for quick fixes.
   1. Login if you have an account.


### PR DESCRIPTION
The deploy to heroku button isn't working due to github's content source policy. I'm adding a backup so we have another link that works even if the button doesn't render.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/ufo-management-server-flask/274)

<!-- Reviewable:end -->
